### PR TITLE
Remove TRUFFLERUBY_{JVM,NATIVE}_STANDALONE_RELEASE_ARCHIVE in suite.py

### DIFF
--- a/mx.truffleruby/mx_truffleruby.py
+++ b/mx.truffleruby/mx_truffleruby.py
@@ -28,7 +28,7 @@ import mx_unittest
 
 # re-export custom mx project classes, so they can be used from suite.py
 from mx_sdk_shaded import ShadedLibraryProject # pylint: disable=unused-import
-from mx_sdk_vm_ng import StandaloneLicenses, ThinLauncherProject, LanguageLibraryProject, DynamicPOMDistribution, DeliverableStandaloneArchive  # pylint: disable=unused-import
+from mx_sdk_vm_ng import StandaloneLicenses, ThinLauncherProject, LanguageLibraryProject, DynamicPOMDistribution  # pylint: disable=unused-import
 
 # Fail early and clearly when trying to build with a too old JDK
 jdk = mx.get_jdk(mx.JavaCompliance('11+'), 'building TruffleRuby which requires JDK 11 or newer')

--- a/mx.truffleruby/suite.py
+++ b/mx.truffleruby/suite.py
@@ -1014,24 +1014,6 @@ suite = {
             },
         },
 
-        "TRUFFLERUBY_NATIVE_STANDALONE_RELEASE_ARCHIVE": {
-            "class": "DeliverableStandaloneArchive",
-            "platformDependent": True,
-            "standalone_dist": "TRUFFLERUBY_NATIVE_STANDALONE",
-            "community_archive_name": "truffleruby-community",
-            "enterprise_archive_name": "truffleruby",
-            "language_id": "ruby",
-        },
-
-        "TRUFFLERUBY_JVM_STANDALONE_RELEASE_ARCHIVE": {
-            "class": "DeliverableStandaloneArchive",
-            "platformDependent": True,
-            "standalone_dist": "TRUFFLERUBY_JVM_STANDALONE",
-            "community_archive_name": "truffleruby-community-jvm",
-            "enterprise_archive_name": "truffleruby-jvm",
-            "language_id": "ruby",
-        },
-
         "TRUFFLERUBY_GRAALVM_LICENSES": {
             "fileListPurpose": "native-image-resources",
             "native": True,


### PR DESCRIPTION
* They cause an extra copy on disk.
* They are not useful anymore to deploy truffleruby standalones.