### PR TITLE
Qualify the Ruby manager link with the git worktree name

### DIFF
--- a/doc/contributor/workflow.md
+++ b/doc/contributor/workflow.md
@@ -105,11 +105,49 @@ Builds are created in the `mxbuild/truffleruby-${BUILD_NAME}` directory. By defa
 name of the build configuration, but you can specify a different name with `--name BUILD_NAME`. This enables
 you to store multiple builds that use the same configuration. Note that if you want to compare multiple builds using
 the same `--env` then you need to use `--name` for all of them.
-Without `--name`, `mxbuild/truffleruby-${env}` is just a symlink and will be reused by any build of the same `--env`.
+Without `--name`, `mxbuild/truffleruby-${env}` is overwritten by any build of the same `--env`.
 
 Note that build information such as the date and Git revision hash will not be
 updated when you build for a second time. Releases should always be built from
 scratch.
+
+### Using git worktrees
+
+Each git worktree has its own `mxbuild` directory, so builds in different worktrees are isolated from
+each other. `jt --use BUILD_NAME` always resolves to a build of the worktree you run it from. Within
+that worktree, `jt build` with the optional `--env`, `--name`, and `--use` flags will function the same
+as if you weren't using worktrees.
+
+While `jt` can be scope builds per worktree, the Ruby version manager symlinks that `jt build` creates
+are necessarily global. To avoid conflicts, the symlink name is augmented to add the worktree name as a
+suffix. Whereas without worktrees the symlink name would be `truffleruby-${BUILD_NAME}`,
+with worktrees it will be `truffleruby-${BUILD_NAME}-${WORKTREE}`.
+
+Without worktrees:
+
+```bash
+cd master && jt build --env jvm-ce
+rbenv shell truffleruby-jvm-ce
+```
+
+With worktrees:
+
+```bash
+cd my-worktree && jt build --env jvm-ce
+rbenv shell truffleruby-jvm-ce-my-worktree
+```
+
+There is one exception to this rule: if a worktree has the default branch (master) checked out, you
+will get the same bare symlink name as you would if you weren't using worktrees at all. Since a branch
+can only be checked out in one worktree, there's no risk of a name clash. That makes adopting git
+worktrees very easy -- as long as you're building master nothing changes. It also helps with communication
+between two contributors, one of which may be using worktrees and the other not, because instructions
+such as "build it and then `chruby truffleruby-jvm-ce`" work the same in either case.
+
+Because each build type in each worktree will create a symlink in the Ruby version manager, the number
+of symlinks could grow quite large. Tools such as [Worktrunk](https://worktrunk.dev/) can be used to
+clean up these symlinks when a worktree is deleted. Otherwise, `jt build` will scan the symlinks on its
+next invocation and remove any that no longer point to a build.
 
 ### Using the correct version of the graal repository
 

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -399,6 +399,18 @@ module Utilities
     `GIT_DIR="#{repo}/.git" git describe --tags --exact-match HEAD 2>/dev/null`.strip
   end
 
+  # The linked worktree name of this checkout or `nil` if the checkout isn't
+  # inside a linked worktree.
+  def git_worktree_name
+    return @git_worktree_name if defined?(@git_worktree_name)
+
+    git_dir, common_dir =
+      `GIT_DIR="#{TRUFFLERUBY_DIR}/.git" git rev-parse --git-dir --git-common-dir 2>/dev/null`.lines.map(&:strip)
+
+    linked = git_dir && common_dir && git_dir != common_dir
+    @git_worktree_name = linked ? File.basename(TRUFFLERUBY_DIR) : nil
+  end
+
   def no_gem_vars_env
     {
       'GEM_HOME' => nil,
@@ -2611,19 +2623,56 @@ module Commands
     rubies_dir = chruby_versions if File.directory?(chruby_versions)
 
     if rubies_dir
+      # `mxbuild` lives inside the checkout, so builds in different checkouts never
+      # collide, but the version manager's directory is a single namespace shared
+      # by every checkout on the machine. Two git worktrees building the same
+      # `--env` would otherwise fight over one link, leaving it pointing at
+      # whichever of them built last. Qualify the link with the worktree name so
+      # each worktree gets its own entry.
+      #
+      # The unqualified name is reserved for the build someone would get without
+      # using worktrees at all, the main worktree of a repository, or whichever
+      # worktree has `master` checked out. Git allows a branch to be checked out
+      # in one worktree at a time, so at most one checkout can claim the name
+      # that way. This keeps instructions passed between contributors ("build it
+      # and then `chruby truffleruby-jvm-ce`") working the same for the reader
+      # whether or not they use worktrees.
+      qualify = git_worktree_name && git_branch != 'master'
+      link_name = qualify ? "#{name}-#{git_worktree_name}" : name
+
       Dir.glob(rubies_dir + '/truffleruby-*').each do |link|
         next unless File.symlink?(link)
         next if File.exist?(link)
         target = File.readlink(link)
-        next unless target.start_with?("#{TRUFFLERUBY_DIR}/mxbuild")
+
+        # Prune broken links left by any checkout, not just this one. A link
+        # created from a git worktree that has since been removed can never be
+        # cleaned up by the checkout that created it.
+        next unless target =~ %r{/mxbuild/truffleruby-[^/]+\z}
         puts "Deleting broken link: #{link} -> #{target}"
         File.delete link
       end
 
-      link_path = "#{rubies_dir}/#{name}"
+      link_path = "#{rubies_dir}/#{link_name}"
       unless File.symlink?(link_path) and File.readlink(link_path) == dest
         File.delete(link_path) if File.symlink?(link_path) or File.exist?(link_path)
         File.symlink(dest, link_path)
+        puts "Linked #{link_path} -> #{dest}"
+      end
+
+      # When using worktrees, the name of the symlink is dependent on the branch
+      # name. Notably, the worktree name is not integrated into the symlink name
+      # when building the 'master' branch. While this allows 'master' builds to
+      # work the same regardless of whether worktrees are being used, it creates
+      # a potential problem if a worktree builds 'master' and then switches to
+      # another branch. New builds will now include the worktree name because the
+      # branch isn't 'master', but the bare symlink names will still be present.
+      # This pass removes those old symlinks to avoid confusion.
+      Dir.glob(rubies_dir + '/truffleruby-*').each do |link|
+        next if link == link_path
+        next unless File.symlink?(link) and File.readlink(link) == dest
+        puts "Deleting superseded link: #{link} -> #{dest}"
+        File.delete link
       end
     end
   end


### PR DESCRIPTION
This change allows multiple git worktrees to perform builds and have each of those builds accessible from a Ruby version manager. Otherwise, whichever worktree builds most recently will take over the Ruby version manager symlink. It effectively sandboxes each worktree with all `jt` commands and flags resolving relative to the worktree. While `--name` exists, that forces loading of the core library from an mxbuild directory, which requires a full build on every core library file change, which isn't great for active development.

If you don't use git worktrees, nothing changes. If you do adopt worktrees, working with the _master_ branch also works the same as today. The new symlink naming only goes into effect for linked worktrees working on branches other than _master_. This allows working on multiple workstreams without having to switch branches and constantly rebuild. And it's very helpful when working with AI agents as they can each work in a sandbox without needing to do a full git clone.