### PR TITLE
Fix IO#reopen with path argument when itself was opened in append mode

### DIFF
--- a/spec/ruby/core/file/open_spec.rb
+++ b/spec/ruby/core/file/open_spec.rb
@@ -386,7 +386,7 @@ describe "File.open" do
     File.should.exist?(@file)
   end
 
-  it "opens a file when use File::WRONLY|File::APPEND mode" do
+  it "opens a file in the read-write append mode when given mode File::RDWR|File::APPEND" do
     File.open(@file, File::WRONLY) do |f|
       f.puts("hello file")
     end
@@ -397,6 +397,21 @@ describe "File.open" do
       f.gets.should == "bye file\n"
       f.gets.should == nil
     end
+  end
+
+  it "opens a file in the append mode when given mode 'a'" do
+    File.write(@file, "hello")
+    File.open(@file, "a") { |f| f.write(" world") }
+    File.read(@file).should == "hello world"
+  end
+
+  it "opens a file in the read-write append mode when given mode 'a+'" do
+    File.write(@file, "hello")
+    File.open(@file, "a+") do |f|
+      f.read.should == "hello"
+      f.write(" world")
+    end
+    File.read(@file).should == "hello world"
   end
 
   it "raises an IOError if the file exists when open with File::RDONLY|File::APPEND" do

--- a/spec/ruby/optional/capi/ext/io_spec.c
+++ b/spec/ruby/optional/capi/ext/io_spec.c
@@ -418,6 +418,9 @@ void Init_io_spec(void) {
   rb_define_const(cls, "FMODE_WRITABLE", INT2FIX(FMODE_WRITABLE));
   rb_define_const(cls, "FMODE_BINMODE", INT2FIX(FMODE_BINMODE));
   rb_define_const(cls, "FMODE_TEXTMODE", INT2FIX(FMODE_TEXTMODE));
+  rb_define_const(cls, "FMODE_CREATE", INT2FIX(FMODE_CREATE));
+  rb_define_const(cls, "FMODE_APPEND", INT2FIX(FMODE_APPEND));
+  rb_define_const(cls, "FMODE_TRUNC", INT2FIX(FMODE_TRUNC));
   rb_define_const(cls, "ECONV_UNIVERSAL_NEWLINE_DECORATOR", INT2FIX(ECONV_UNIVERSAL_NEWLINE_DECORATOR));
 }
 

--- a/spec/ruby/optional/capi/io_spec.rb
+++ b/spec/ruby/optional/capi/io_spec.rb
@@ -669,6 +669,43 @@ describe "C-API IO function" do
       (@o.rb_io_mode(@w_io) & 0b11).should == 0b10
       (@o.rb_io_mode(@rw_io) & 0b11).should == 0b11
     end
+
+    it "includes FMODE_APPEND when in append mode" do
+      io = File.open(@name, "a")
+      begin
+        (@o.rb_io_mode(io) & 0x40).should == 0x40
+      ensure
+        io.close
+      end
+    end
+
+    it "includes FMODE_BINMODE when in binary mode" do
+      io = File.open(@name, "rb")
+      begin
+        (@o.rb_io_mode(io) & 0x04).should == 0x04
+      ensure
+        io.close
+      end
+    end
+
+    it "includes FMODE_CREATE when the file is created" do
+      rm_r @name
+      io = File.open(@name, "w")
+      begin
+        (@o.rb_io_mode(io) & 0x80).should == 0x80
+      ensure
+        io.close
+      end
+    end
+
+    it "includes FMODE_TRUNC when the file is truncated" do
+      io = File.open(@name, "w")
+      begin
+        (@o.rb_io_mode(io) & 0x800).should == 0x800
+      ensure
+        io.close
+      end
+    end
   end
 
   describe "rb_io_path" do

--- a/spec/ruby/optional/capi/io_spec.rb
+++ b/spec/ruby/optional/capi/io_spec.rb
@@ -673,7 +673,7 @@ describe "C-API IO function" do
     it "includes FMODE_APPEND when in append mode" do
       io = File.open(@name, "a")
       begin
-        (@o.rb_io_mode(io) & 0x40).should == 0x40
+        (@o.rb_io_mode(io) & CApiIOSpecs::FMODE_APPEND).should == CApiIOSpecs::FMODE_APPEND
       ensure
         io.close
       end
@@ -682,7 +682,7 @@ describe "C-API IO function" do
     it "includes FMODE_BINMODE when in binary mode" do
       io = File.open(@name, "rb")
       begin
-        (@o.rb_io_mode(io) & 0x04).should == 0x04
+        (@o.rb_io_mode(io) & CApiIOSpecs::FMODE_BINMODE).should == CApiIOSpecs::FMODE_BINMODE
       ensure
         io.close
       end
@@ -692,7 +692,7 @@ describe "C-API IO function" do
       rm_r @name
       io = File.open(@name, "w")
       begin
-        (@o.rb_io_mode(io) & 0x80).should == 0x80
+        (@o.rb_io_mode(io) & CApiIOSpecs::FMODE_CREATE).should == CApiIOSpecs::FMODE_CREATE
       ensure
         io.close
       end
@@ -701,7 +701,7 @@ describe "C-API IO function" do
     it "includes FMODE_TRUNC when the file is truncated" do
       io = File.open(@name, "w")
       begin
-        (@o.rb_io_mode(io) & 0x800).should == 0x800
+        (@o.rb_io_mode(io) & CApiIOSpecs::FMODE_TRUNC).should == CApiIOSpecs::FMODE_TRUNC
       ensure
         io.close
       end

--- a/spec/tags/core/io/reopen_tags.txt
+++ b/spec/tags/core/io/reopen_tags.txt
@@ -1,2 +1,1 @@
 slow:IO#reopen with a String affects exec/system/fork performed after it
-fails:IO#reopen with a String opens the file in append mode if the IO appends

--- a/src/main/ruby/truffleruby/core/io.rb
+++ b/src/main/ruby/truffleruby/core/io.rb
@@ -818,11 +818,9 @@ class IO
 
     if mode
       mode = Truffle::IOOperations.parse_mode(mode)
-      mode &= ACCMODE
     elsif !Truffle::Boot.preinitializing? && Truffle::POSIX::NATIVE
       mode = Truffle::POSIX.fcntl(fd, F_GETFL, 0)
       Errno.handle if mode < 0
-      mode &= ACCMODE
     else
       raise 'No mode given for IO'
     end
@@ -834,7 +832,7 @@ class IO
     Primitive.object_ivar_set io, :@mode, Truffle::IOOperations.translate_omode_to_fmode(mode)
     io.sync = sync
     io.autoclose  = true
-    ibuffer = mode != WRONLY ? IO::InternalBuffer.new : nil
+    ibuffer = (mode & ACCMODE) != WRONLY ? IO::InternalBuffer.new : nil
     Primitive.object_ivar_set io, :@ibuffer, ibuffer
     Primitive.object_ivar_set io, :@lineno, 0
   end
@@ -2017,7 +2015,7 @@ class IO
       mode = Truffle::POSIX.fcntl(Primitive.io_fd(self), F_GETFL, 0)
       Errno.handle if mode < 0
 
-      @mode = Truffle::IOOperations.translate_omode_to_fmode((mode & ACCMODE))
+      @mode = Truffle::IOOperations.translate_omode_to_fmode(mode)
       @ibuffer = (@mode & FMODE_READABLE) != 0 ? IO::InternalBuffer.new : nil
     end
 


### PR DESCRIPTION
Fix `IO#reopen` to correctly preserve append mode when the stream was opened in append mode.

## Notes

Applying the `ACCMODE` mask in `IO#initialize` is incorrect because it prematurely discards open and status flags (specifically `O_APPEND`, `O_CREAT`, `O_TRUNC`, and `O_BINARY`) before they can be translated into internal `FMODE_ `flags, causing subsequent operations like `IO#reopen` to lose state and fail to append.

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
