### PR TITLE
Fix IO#seek called after #ungetc

### DIFF
--- a/spec/ruby/core/io/rewind_spec.rb
+++ b/spec/ruby/core/io/rewind_spec.rb
@@ -47,6 +47,14 @@ describe "IO#rewind" do
     @io.rewind.should == 0
   end
 
+  ruby_bug "#20919", "" ... "3.4" do
+    it "clears the character buffer" do
+      @io.ungetc("a")
+      @io.rewind
+      @io.getc.should == "V"
+    end
+  end
+
   it "raises IOError on closed stream" do
     -> { IOSpecs.closed_io.rewind }.should.raise(IOError)
   end

--- a/spec/ruby/core/io/seek_spec.rb
+++ b/spec/ruby/core/io/seek_spec.rb
@@ -88,6 +88,13 @@ describe "IO#seek" do
       @io.seek(1, IO::SEEK_SET)
       @io.getc.should == "o".encode(Encoding::UTF_16LE)
     end
+
+    it "clears the character buffer even when ungotten characters exceed consumed characters" do
+      @io.getc.should == "V"
+      @io.ungetc("123456")
+      @io.seek(1, IO::SEEK_SET)
+      @io.getc.should == "o"
+    end
   end
 
   platform_is :darwin do

--- a/spec/ruby/core/io/ungetc_spec.rb
+++ b/spec/ruby/core/io/ungetc_spec.rb
@@ -108,6 +108,12 @@ describe "IO#ungetc" do
     @io.gets.chomp.should == "Aquí Qui è la linea due."
   end
 
+  it "puts correctly back a string longer than the amount of data previously read" do
+    @io.read(5).should == "Voici"
+    @io.ungetc("1234567890").should == nil
+    @io.gets.chomp.should == "1234567890 la ligne une."
+  end
+
   it "calls #to_str to convert the argument if it is not an Integer" do
     chars = mock("io ungetc")
     chars.should_receive(:to_str).and_return("Aquí ")

--- a/spec/tags/core/io/seek_tags.txt
+++ b/spec/tags/core/io/seek_tags.txt
@@ -1,1 +1,0 @@
-fails:IO#seek clears the character buffer

--- a/spec/tags/core/io/sysseek_tags.txt
+++ b/spec/tags/core/io/sysseek_tags.txt
@@ -1,1 +1,0 @@
-fails:IO#sysseek raises an error when called after buffered reads

--- a/src/main/java/org/truffleruby/core/support/ByteArrayNodes.java
+++ b/src/main/java/org/truffleruby/core/support/ByteArrayNodes.java
@@ -75,26 +75,26 @@ public abstract class ByteArrayNodes {
 
     }
 
-    @CoreMethod(names = "prepend", required = 1)
+    @CoreMethod(names = "prepend", required = 3, lowerFixnum = { 2, 3 })
     public abstract static class PrependNode extends CoreMethodArrayArgumentsNode {
 
         @Specialization(guards = "strings.isRubyString(node, string)", limit = "1")
-        static RubyByteArray prepend(RubyByteArray byteArray, Object string,
+        static RubyByteArray prepend(RubyByteArray byteArray, Object string, int srcStart, int length,
                 @Bind Node node,
                 @Cached RubyStringLibrary strings,
-                @Cached TruffleString.CopyToByteArrayNode copyToByteArrayNode) {
+                @Cached TruffleString.GetInternalByteArrayNode getInternalByteArrayNode) {
             final byte[] bytes = byteArray.bytes;
 
             var tstring = strings.getTString(node, string);
             var encoding = strings.getTEncoding(node, string);
 
-            final int prependLength = tstring.byteLength(encoding);
             final int originalLength = bytes.length;
-            final int newLength = prependLength + originalLength;
+            final int newLength = length + originalLength;
             final byte[] prependedBytes = new byte[newLength];
 
-            copyToByteArrayNode.execute(tstring, 0, prependedBytes, 0, prependLength, encoding);
-            System.arraycopy(bytes, 0, prependedBytes, prependLength, originalLength);
+            var stringBytes = getInternalByteArrayNode.execute(tstring, encoding);
+            System.arraycopy(stringBytes.getArray(), stringBytes.getOffset() + srcStart, prependedBytes, 0, length);
+            System.arraycopy(bytes, 0, prependedBytes, length, originalLength);
 
             final RubyByteArray instance = new RubyByteArray(
                     coreLibrary(node).byteArrayClass,
@@ -132,10 +132,12 @@ public abstract class ByteArrayNodes {
         static Object fillFromString(RubyByteArray destByteArray, int dstStart, Object source, int srcStart, int length,
                 @Bind Node node,
                 @Cached RubyStringLibrary strings,
-                @Cached TruffleString.CopyToByteArrayNode copyToByteArrayNode) {
+                @Cached TruffleString.GetInternalByteArrayNode getInternalByteArrayNode) {
             var tstring = strings.getTString(node, source);
             var encoding = strings.getTEncoding(node, source);
-            copyToByteArrayNode.execute(tstring, srcStart, destByteArray.bytes, dstStart, length, encoding);
+            var stringBytes = getInternalByteArrayNode.execute(tstring, encoding);
+            System.arraycopy(stringBytes.getArray(), stringBytes.getOffset() + srcStart, destByteArray.bytes, dstStart,
+                    length);
             return source;
         }
 

--- a/src/main/java/org/truffleruby/core/support/ByteArrayNodes.java
+++ b/src/main/java/org/truffleruby/core/support/ByteArrayNodes.java
@@ -25,7 +25,6 @@ import org.truffleruby.builtins.CoreMethodArrayArgumentsNode;
 import org.truffleruby.builtins.PrimitiveArrayArgumentsNode;
 import org.truffleruby.core.encoding.TStringUtils;
 import org.truffleruby.core.klass.RubyClass;
-import org.truffleruby.core.string.RubyString;
 import org.truffleruby.extra.ffi.Pointer;
 import org.truffleruby.extra.ffi.PointerNodes;
 import org.truffleruby.extra.ffi.RubyPointer;
@@ -129,12 +128,13 @@ public abstract class ByteArrayNodes {
     @CoreMethod(names = "fill", required = 4, lowerFixnum = { 1, 3, 4 })
     public abstract static class FillNode extends CoreMethodArrayArgumentsNode {
 
-        @Specialization
-        Object fillFromString(RubyByteArray destByteArray, int dstStart, RubyString source, int srcStart, int length,
-                @Cached RubyStringLibrary libString,
+        @Specialization(guards = "strings.isRubyString(node, source)", limit = "1")
+        static Object fillFromString(RubyByteArray destByteArray, int dstStart, Object source, int srcStart, int length,
+                @Bind Node node,
+                @Cached RubyStringLibrary strings,
                 @Cached TruffleString.CopyToByteArrayNode copyToByteArrayNode) {
-            var tstring = source.tstring;
-            var encoding = libString.getTEncoding(this, source);
+            var tstring = strings.getTString(node, source);
+            var encoding = strings.getTEncoding(node, source);
             copyToByteArrayNode.execute(tstring, srcStart, destByteArray.bytes, dstStart, length, encoding);
             return source;
         }

--- a/src/main/ruby/truffleruby/core/io.rb
+++ b/src/main/ruby/truffleruby/core/io.rb
@@ -2243,7 +2243,7 @@ class IO
   #  f.sysread(10)                  #=> "And so on."
   def sysseek(amount, whence = SEEK_SET)
     ensure_open
-    raise IOError unless buffer_empty?
+    raise IOError, 'sysseek for buffered IO' unless buffer_empty?
 
     whence = Truffle::IOOperations.parse_whence(whence)
     r = Truffle::POSIX.lseek(Primitive.io_fd(self), Primitive.rb_num2long(amount), whence)

--- a/src/main/ruby/truffleruby/core/io.rb
+++ b/src/main/ruby/truffleruby/core/io.rb
@@ -217,7 +217,7 @@ class IO
           pos = Truffle::POSIX.lseek(io.fileno, 0, IO::SEEK_CUR)
           Errno.handle if pos == -1
           # Prevent seeking past 0 to handle bytes prepended via #ungetc
-          amount = -pos if amount < -pos
+          amount = -pos if amount + pos < 0
 
           if amount < 0
             r = Truffle::POSIX.lseek(io.fileno, amount, IO::SEEK_CUR)
@@ -304,12 +304,12 @@ class IO
           @start -= length
           @storage.fill(@start, str, 0, length)
         else
-          unread = Primitive.string_from_bytearray(@storage, @start, size, Encoding::BINARY)
-          prepended_str = str.b + unread
-          @storage = Truffle::ByteArray.new(0).prepend(prepended_str)
-          @total = prepended_str.bytesize
+          prepend_length = length - @start
+          @storage = @storage.prepend(str, 0, prepend_length)
+          @storage.fill(prepend_length, str, prepend_length, @start) if @start > 0
+          @total += prepend_length
+          @used += prepend_length
           @start = 0
-          @used = @total
         end
       end
     end

--- a/src/main/ruby/truffleruby/core/io.rb
+++ b/src/main/ruby/truffleruby/core/io.rb
@@ -290,18 +290,20 @@ class IO
     # Prepends the bytes of string +str+ to the internal buffer,
     # so that future reads will return them.
     def put_back(str)
-      length = str.bytesize
-      # A simple case, which is common and can be done efficiently
-      if @start >= length
-        @start -= length
-        str.bytes.each_with_index do |byte, i|
-          @storage[@start+i] = byte
+      TruffleRuby.synchronized(self) do
+        length = str.bytesize
+        # A simple case, which is common and can be done efficiently
+        if @start >= length
+          @start -= length
+          @storage.fill(@start, str, 0, length)
+        else
+          unread = Primitive.string_from_bytearray(@storage, @start, size, Encoding::BINARY)
+          prepended_str = str.b + unread
+          @storage = Truffle::ByteArray.new(0).prepend(prepended_str)
+          @total = prepended_str.bytesize
+          @start = 0
+          @used = @total
         end
-      else
-        @storage = @storage.prepend(str)
-        @total += length
-        @start = 0
-        @used += length
       end
     end
 

--- a/src/main/ruby/truffleruby/core/io.rb
+++ b/src/main/ruby/truffleruby/core/io.rb
@@ -214,8 +214,15 @@ class IO
       TruffleRuby.synchronized(self) do
         unless empty?
           amount = @start - @used
-          r = Truffle::POSIX.lseek(io.fileno, amount, IO::SEEK_CUR)
-          Errno.handle if r == -1
+          pos = Truffle::POSIX.lseek(io.fileno, 0, IO::SEEK_CUR)
+          Errno.handle if pos == -1
+          # Prevent seeking past 0 to handle bytes prepended via #ungetc
+          amount = -pos if amount < -pos
+
+          if amount < 0
+            r = Truffle::POSIX.lseek(io.fileno, amount, IO::SEEK_CUR)
+            Errno.handle if r == -1
+          end
         end
         reset!
       end


### PR DESCRIPTION
Follow up for #4400.

Changes:
- fixed IO#ungetc when pushed-back string exceeds consumed bytes in buffer
- fixed IO#seek after #ungetc
- fixed IO#sysseek and raise IOError with a proper message (change only message)

## Notes for the #ungetc's fix

When calling `ungetc` or `ungetbyte` with a string longer than the amount of consumed bytes in the buffer (`str.bytesize > @start`), the buffer prepended the string directly to the entire backing byte array. This kept already-consumed bytes in the buffer, causing them to be incorrectly duplicated and reread on subsequent reads.

Additionally, using `@storage.fill` with frozen strings (e.g., `ImmutableRubyString` literals like `?a`) crashed on the JVM due to a missing specialization error in the Java ByteArrayNodes.java.


## Notes for the #seek's fix

Due to read-ahead buffering, the OS file descriptor is positioned ahead of the logical stream position. When the buffer is cleared during `#seek`, a phisical position should be adjusted to match the logical one so the next read starts at  the correct place. However, because unread OS bytes and ungotten bytes (from `ungetc`) weren't distinguished, incorrect seek-back offset was calculated, leading to incorrect positioning or `EINVAL` errors.

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
