### PR TITLE
Fix IO#set_encoding and improve parameters validation

### DIFF
--- a/spec/ruby/core/encoding/find_spec.rb
+++ b/spec/ruby/core/encoding/find_spec.rb
@@ -53,6 +53,10 @@ describe "Encoding.find" do
     -> { Encoding.find('dh2dh278d') }.should.raise(ArgumentError, 'unknown encoding name - dh2dh278d')
   end
 
+  it "raises an ArgumentError when the name is in a non-ASCII-compatible encoding" do
+    -> { Encoding.find("utf-8".encode("utf-16be")) }.should.raise(ArgumentError, "invalid encoding name (non ASCII)")
+  end
+
   # Not sure how to do a better test, since locale depends on weird platform-specific stuff
   it "supports the 'locale' encoding alias" do
     enc = Encoding.find('locale')

--- a/spec/ruby/core/io/external_encoding_spec.rb
+++ b/spec/ruby/core/io/external_encoding_spec.rb
@@ -118,6 +118,12 @@ describe "IO#external_encoding" do
         @io.external_encoding.should.equal?(Encoding::IBM437)
       end
 
+      it "returns the value of Encoding.default_external when the instance was created if only the internal encoding is set" do
+        @io = new_io @name, mode: "r", internal_encoding: "utf-8"
+        Encoding.default_external = Encoding::IBM437
+        @io.external_encoding.should.equal?(Encoding::IBM866)
+      end
+
       it "returns the external encoding specified when the instance was created" do
         @io = new_io @name, "r:utf-8"
         Encoding.default_external = Encoding::IBM437

--- a/spec/ruby/core/io/set_encoding_spec.rb
+++ b/spec/ruby/core/io/set_encoding_spec.rb
@@ -313,6 +313,7 @@ describe "IO#set_encoding" do
 
   it "raises ArgumentError when argument is not ASCII compatible" do
     -> { @io.set_encoding("utf-8".encode(Encoding::UTF_16BE)) }.should.raise(ArgumentError)
+    -> { @io.set_encoding("utf-8", "utf-8".encode(Encoding::UTF_16BE)) }.should.raise(ArgumentError)
   end
 
   it "raises TypeError when the first argument is nil and the second is not nil" do
@@ -335,6 +336,10 @@ describe "IO#set_encoding" do
 
     -> {
       io.set_encoding(Encoding::UTF_16BE)
+    }.should.raise(ArgumentError, "ASCII incompatible encoding needs binmode")
+
+    -> {
+      io.set_encoding("utf-16be")
     }.should.raise(ArgumentError, "ASCII incompatible encoding needs binmode")
 
     Encoding.default_external = Encoding::UTF_16BE
@@ -392,6 +397,15 @@ describe "IO#set_encoding" do
     @io.binmode
     -> {
       @io.set_encoding("utf-8", newline: :lf)
+    }.should.raise(ArgumentError, "newline decorator with binary mode")
+    -> {
+      @io.set_encoding("utf-8", universal_newline: true)
+    }.should.raise(ArgumentError, "newline decorator with binary mode")
+    -> {
+      @io.set_encoding("utf-8", crlf_newline: true)
+    }.should.raise(ArgumentError, "newline decorator with binary mode")
+    -> {
+      @io.set_encoding("utf-8", cr_newline: true)
     }.should.raise(ArgumentError, "newline decorator with binary mode")
   end
 

--- a/spec/tags/core/io/set_encoding_tags.txt
+++ b/spec/tags/core/io/set_encoding_tags.txt
@@ -1,6 +1,1 @@
 fails:IO#set_encoding saves encoding options passed as a hash in the last argument
-fails:IO#set_encoding raises ArgumentError when argument is not ASCII compatible
-fails:IO#set_encoding raises TypeError when the first argument is nil and the second is not nil
-fails:IO#set_encoding raises ArgumentError when newline decorator has invalid value
-fails:IO#set_encoding raises ArgumentError when ASCII incompatible encoding is used with readable stream without binmode or character conversion
-fails:IO#set_encoding raises ArgumentError when newline decorator provided in binary mode

--- a/src/main/ruby/truffleruby/core/encoding.rb
+++ b/src/main/ruby/truffleruby/core/encoding.rb
@@ -99,6 +99,10 @@ class Encoding
       str = Primitive.convert_with_to_str(obj)
     end
 
+    unless str.encoding.ascii_compatible?
+      raise ArgumentError, 'invalid encoding name (non ASCII)'
+    end
+
     key = str.upcase.to_sym
 
     pair = EncodingMap[key]

--- a/src/main/ruby/truffleruby/core/io.rb
+++ b/src/main/ruby/truffleruby/core/io.rb
@@ -2086,10 +2086,27 @@ class IO
   # Otherwise         => enc is external, enc2 is internal
   #
   # We use the internal and external terminology only because enc/enc2 is so confusing.
-  def set_encoding(external, internal = nil, **options)
+  def set_encoding(external, internal = nil, newline: nil, **options)
+    unless Primitive.nil?(newline)
+      if Primitive.is_a?(newline, Symbol)
+        unless newline == :universal || newline == :crlf || newline == :cr || newline == :lf
+          raise ArgumentError, "unexpected value for newline option: #{newline}"
+        end
+      else
+        raise ArgumentError, 'unexpected value for newline option'
+      end
+    end
+
+    if binmode?
+      if options[:universal_newline] || options[:crlf_newline] || options[:cr_newline] || !Primitive.nil?(newline)
+        raise ArgumentError, 'newline decorator with binary mode'
+      end
+    end
+
     if !Primitive.nil?(internal)
-      unless Primitive.nil?(external) || Primitive.is_a?(external, Encoding)
-        external = Truffle::IOOperations.parse_external_enc(self, Primitive.convert_with_to_str(external), @mode)
+      unless Primitive.is_a?(external, Encoding)
+        external = Primitive.convert_with_to_str(external)
+        external = Truffle::IOOperations.parse_external_enc(self, external, @mode)
       end
 
       unless Primitive.is_a?(internal, Encoding)
@@ -2107,15 +2124,33 @@ class IO
         internal = nil
       end
     else
+      unless Primitive.nil?(external) || Primitive.is_a?(external, Encoding)
+        external = Primitive.convert_with_to_str(external)
+        unless external.encoding.ascii_compatible?
+          raise ArgumentError, 'invalid encoding name (non ASCII)'
+        end
+      end
+
       if Primitive.nil?(external) # Set to default encodings
         external, internal = Truffle::IOOperations.rb_io_ext_int_to_encs(@mode, nil, nil)
       else
-        if !Primitive.is_a?(external, Encoding) and
-            external = Primitive.convert_with_to_str(external) and external.encoding.ascii_compatible?
+        if !Primitive.is_a?(external, Encoding)
           external, internal = Truffle::IOOperations.parse_mode_enc(self, @mode, external)
         else
           external, internal = Truffle::IOOperations.rb_io_ext_int_to_encs(@mode, Encoding.find(external), nil)
         end
+      end
+    end
+
+    # MRI: validate_enc_binmode
+    effective_external = external
+    if Primitive.nil?(effective_external) && @mode.anybits?(FMODE_READABLE)
+      effective_external = Encoding.default_external
+    end
+
+    if !Primitive.nil?(effective_external) && !effective_external.ascii_compatible?
+      if @mode.anybits?(FMODE_READABLE) && !binmode? && Primitive.nil?(internal)
+        raise ArgumentError, 'ASCII incompatible encoding needs binmode'
       end
     end
 

--- a/src/main/ruby/truffleruby/core/truffle/io_operations.rb
+++ b/src/main/ruby/truffleruby/core/truffle/io_operations.rb
@@ -576,6 +576,11 @@ module Truffle
           path = Primitive.convert_with_to_str(path)
         end
       end
+
+      if Primitive.nil?(external) && !Primitive.nil?(internal)
+        external = Encoding.default_external
+      end
+
       external = Encoding::BINARY if binary and !external and !internal
       perm ||= 0666
       [mode, binary, external, internal, autoclose, perm, path]


### PR DESCRIPTION
Follow up for https://github.com/truffleruby/truffleruby/pull/4400.

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
