### PR TITLE
Fix Kernel#__callee__ and Kernel#__method__ when called outside a method body

### DIFF
--- a/spec/tags/core/kernel/__callee___tags.txt
+++ b/spec/tags/core/kernel/__callee___tags.txt
@@ -1,4 +1,0 @@
-fails:Kernel.__callee__ returns nil when not called from a method
-fails:Kernel.__callee__ returns nil from inside a class body
-fails:Kernel#__callee__ returns nil from inside a class body
-fails:Kernel#__callee__ returns nil when not called from a method

--- a/spec/tags/core/kernel/__method___tags.txt
+++ b/spec/tags/core/kernel/__method___tags.txt
@@ -1,4 +1,0 @@
-fails:Kernel.__method__ returns nil from inside a class body
-fails:Kernel.__method__ returns nil when not called from a method
-fails:Kernel#__method__ returns nil from inside a class body
-fails:Kernel#__method__ returns nil when not called from a method

--- a/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
+++ b/src/main/java/org/truffleruby/core/kernel/KernelNodes.java
@@ -367,9 +367,16 @@ public abstract class KernelNodes {
     public abstract static class CalleeNameNode extends CoreMethodArrayArgumentsNode {
 
         @Specialization
-        RubySymbol calleeName() {
+        Object calleeName() {
             // the "called name" of a method.
-            return getSymbol(getContext().getCallStack().getCallingMethod().getName());
+            final InternalMethod callingMethod = getContext().getCallStack().getCallingMethod();
+            assert callingMethod != null;
+
+            if (callingMethod.getSharedMethodInfo().isModuleBody()) {
+                return nil;
+            }
+
+            return getSymbol(callingMethod.getName());
         }
     }
 
@@ -1195,9 +1202,15 @@ public abstract class KernelNodes {
     public abstract static class MethodNameNode extends CoreMethodArrayArgumentsNode {
 
         @Specialization
-        RubySymbol methodName() {
+        Object methodName() {
             // the "original/definition name" of the method.
-            InternalMethod internalMethod = getContext().getCallStack().getCallingMethod();
+            final InternalMethod internalMethod = getContext().getCallStack().getCallingMethod();
+            assert internalMethod != null;
+
+            if (internalMethod.getSharedMethodInfo().isModuleBody()) {
+                return nil;
+            }
+
             return getSymbol(internalMethod.getSharedMethodInfo().getMethodName());
         }
 


### PR DESCRIPTION
Follow up for #4366.

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
