### PR TITLE
[Ruby 4.0] Implement character selector parameters in String strip-like methods

### DIFF
--- a/spec/ruby/core/string/count_spec.rb
+++ b/spec/ruby/core/string/count_spec.rb
@@ -108,4 +108,9 @@ describe "String#count" do
     -> { "hello world".count([])        }.should.raise(TypeError)
     -> { "hello world".count(mock('x')) }.should.raise(TypeError)
   end
+
+  it "raises an Encoding::CompatibilityError when the encodings are incompatible" do
+    -> { "hello".count("e".encode("UTF-16LE")) }.should.raise(Encoding::CompatibilityError)
+    -> { "hello".encode("UTF-16LE").count("e") }.should.raise(Encoding::CompatibilityError)
+  end
 end

--- a/spec/ruby/core/string/count_spec.rb
+++ b/spec/ruby/core/string/count_spec.rb
@@ -73,20 +73,26 @@ describe "String#count" do
     "abcde".count("^ac-e").should == 1
   end
 
-  it "raises if the given sequences are invalid" do
+  it "raises an ArgumentError when the sequence is invalid" do
     s = "hel-[()]-lo012^"
 
     -> { s.count("h-e") }.should.raise(ArgumentError)
     -> { s.count("^h-e") }.should.raise(ArgumentError)
   end
 
-  it 'returns the number of occurrences of a multi-byte character' do
+  it "counts multibyte characters" do
     str = "\u{2605}"
     str.count(str).should == 1
     "asd#{str}zzz#{str}ggg".count(str).should == 2
   end
 
-  it "calls #to_str to convert each set arg to a String" do
+  it "respects backslash for escaping" do
+    "a-b".count("a\\-b").should == 3
+    "^".count("\\^").should == 1
+    "\\".count("\\\\").should == 1
+  end
+
+  it "tries to convert each argument to a string using to_str" do
     other_string = mock('lo')
     other_string.should_receive(:to_str).and_return("lo")
 
@@ -97,7 +103,7 @@ describe "String#count" do
     s.count(other_string, other_string2).should == s.count("o")
   end
 
-  it "raises a TypeError when a set arg can't be converted to a string" do
+  it "raises a TypeError when an argument can't be converted to a string" do
     -> { "hello world".count(100)       }.should.raise(TypeError)
     -> { "hello world".count([])        }.should.raise(TypeError)
     -> { "hello world".count(mock('x')) }.should.raise(TypeError)

--- a/spec/ruby/core/string/delete_spec.rb
+++ b/spec/ruby/core/string/delete_spec.rb
@@ -95,6 +95,11 @@ describe "String#delete" do
   it "returns a String in the same encoding as self" do
     "hello".encode("US-ASCII").delete("lo").encoding.should == Encoding::US_ASCII
   end
+
+  it "raises an Encoding::CompatibilityError when the encodings are incompatible" do
+    -> { "hello".delete("e".encode("UTF-16LE")) }.should.raise(Encoding::CompatibilityError)
+    -> { "hello".encode("UTF-16LE").delete("e") }.should.raise(Encoding::CompatibilityError)
+  end
 end
 
 describe "String#delete!" do

--- a/spec/ruby/core/string/delete_spec.rb
+++ b/spec/ruby/core/string/delete_spec.rb
@@ -54,12 +54,15 @@ describe "String#delete" do
     '哥哥我倒'.delete('哥').should == "我倒"
   end
 
-  it "respects backslash for escaping a -" do
+  it "respects backslash for escaping" do
     'Non-Authoritative Information'.delete(' \-\'').should ==
       'NonAuthoritativeInformation'
+    "a-b".delete("a\\-b").should == ""
+    "^".delete("\\^").should == ""
+    "\\".delete("\\\\").should == ""
   end
 
-  it "raises if the given ranges are invalid" do
+  it "raises an ArgumentError when the sequence is invalid" do
     not_supported_on :opal do
       xFF = [0xFF].pack('C')
       range = "\x00 - #{xFF}".force_encoding('utf-8')
@@ -69,7 +72,7 @@ describe "String#delete" do
     -> { "hello".delete("^h-e") }.should.raise(ArgumentError)
   end
 
-  it "tries to convert each set arg to a string using to_str" do
+  it "tries to convert each argument to a string using to_str" do
     other_string = mock('lo')
     other_string.should_receive(:to_str).and_return("lo")
 
@@ -79,7 +82,7 @@ describe "String#delete" do
     "hello world".delete(other_string, other_string2).should == "hell wrld"
   end
 
-  it "raises a TypeError when one set arg can't be converted to a string" do
+  it "raises a TypeError when an argument can't be converted to a string" do
     -> { "hello world".delete(100)       }.should.raise(TypeError)
     -> { "hello world".delete([])        }.should.raise(TypeError)
     -> { "hello world".delete(mock('x')) }.should.raise(TypeError)

--- a/spec/ruby/core/string/lstrip_spec.rb
+++ b/spec/ruby/core/string/lstrip_spec.rb
@@ -25,6 +25,74 @@ describe "String#lstrip" do
     "\x00hello".lstrip.should == "hello"
     "\000 \000hello\000 \000".lstrip.should == "hello\000 \000"
   end
+
+  ruby_version_is "4.0" do
+    context "when given character selectors arguments" do
+      it "removes leading characters in the intersection of sets removed" do
+        "  hello  ".lstrip(" ").should == "hello  "
+        "llo".lstrip("lo", "l").should == "o"
+        "hello".lstrip("ho", "h").should == "ello"
+        "hell yeah".lstrip("").should == "hell yeah"
+      end
+
+      it "negates sets starting with ^" do
+        "ello".lstrip("aeiou", "^e").should == "ello"
+        "hello".lstrip("^o").should == "o"
+      end
+
+      it "removes leading characters in a sequence" do
+        "hello".lstrip("e-h").should == "llo"
+        "hel-lo".lstrip("h-").should == "el-lo"
+        "abcdefgh".lstrip("a-ce-fh").should == "defgh"
+        "abcde".lstrip("ac-e").should == "bcde"
+      end
+
+      it "removes leading multibyte characters" do
+        "四月".lstrip("四").should == "月"
+        "哥哥我倒".lstrip("哥").should == "我倒"
+      end
+
+      it "respects backslash for escaping" do
+        "a-b".lstrip("a\\-b").should == ""
+        "^".lstrip("\\^").should == ""
+        "\\".lstrip("\\\\").should == ""
+      end
+
+      it "raises an ArgumentError when the sequence is invalid" do
+        -> { "hello".lstrip("h-e") }.should.raise(ArgumentError)
+        -> { "hello".lstrip("^h-e") }.should.raise(ArgumentError)
+      end
+
+      it "tries to convert each argument to a string using to_str" do
+        other_string = mock('h')
+        other_string.should_receive(:to_str).and_return("h")
+
+        other_string2 = mock('he')
+        other_string2.should_receive(:to_str).and_return("he")
+
+        "hello world".lstrip(other_string, other_string2).should == "ello world"
+      end
+
+      it "raises a TypeError when an argument can't be converted to a string" do
+        -> { "hello world".lstrip(100)       }.should.raise(TypeError)
+        -> { "hello world".lstrip([])        }.should.raise(TypeError)
+        -> { "hello world".lstrip(mock('x')) }.should.raise(TypeError)
+      end
+
+      it "returns String instances when called on a subclass" do
+        StringSpecs::MyString.new("oh no!!!").lstrip("o").should.instance_of?(String)
+      end
+
+      it "returns a String in the same encoding as self" do
+        "hello".encode("US-ASCII").lstrip("h").encoding.should == Encoding::US_ASCII
+      end
+
+      it "raises an Encoding::CompatibilityError when the encodings are incompatible" do
+        -> { "hello".lstrip("e".encode("UTF-16LE")) }.should.raise(Encoding::CompatibilityError)
+        -> { "hello".encode("UTF-16LE").lstrip("e") }.should.raise(Encoding::CompatibilityError)
+      end
+    end
+  end
 end
 
 describe "String#lstrip!" do

--- a/spec/ruby/core/string/rstrip_spec.rb
+++ b/spec/ruby/core/string/rstrip_spec.rb
@@ -25,6 +25,73 @@ describe "String#rstrip" do
   it "returns a copy of self with all trailing whitespace and NULL bytes removed" do
     "\x00 \x00hello\x00 \x00".rstrip.should == "\x00 \x00hello"
   end
+
+  ruby_version_is "4.0" do
+    context "when given character selectors arguments" do
+      it "removes trailing characters in the intersection of sets removed" do
+        "  hello  ".rstrip(" ").should == "  hello"
+        "llo".rstrip("o", "lo").should == "ll"
+        "hell yeah".rstrip("").should == "hell yeah"
+      end
+
+      it "negates sets starting with ^" do
+        "ello".rstrip("aeiou", "^o").should == "ello"
+        "hello".rstrip("^h").should == "h"
+      end
+
+      it "removes trailing characters in a sequence" do
+        "hello".rstrip("l-o").should == "he"
+        "hel-lo".rstrip("h-").should == "hel-lo"
+        "abcdefgh".rstrip("a-ce-fh").should == "abcdefg"
+        "abcde".rstrip("ac-e").should == "ab"
+      end
+
+      it "removes trailing multibyte characters" do
+        "四月".rstrip("月").should == "四"
+        "哥哥我倒".rstrip("倒").should == "哥哥我"
+      end
+
+      it "respects backslash for escaping" do
+        "a-b".rstrip("a\\-b").should == ""
+        "^".rstrip("\\^").should == ""
+        "\\".rstrip("\\\\").should == ""
+      end
+
+      it "raises an ArgumentError when the sequence is invalid" do
+        -> { "hello".rstrip("h-e") }.should.raise(ArgumentError)
+        -> { "hello".rstrip("^h-e") }.should.raise(ArgumentError)
+      end
+
+      it "tries to convert each argument to a string using to_str" do
+        other_string = mock('d')
+        other_string.should_receive(:to_str).and_return("d")
+
+        other_string2 = mock('ld')
+        other_string2.should_receive(:to_str).and_return("ld")
+
+        "hello world".rstrip(other_string, other_string2).should == "hello worl"
+      end
+
+      it "raises a TypeError when an argument can't be converted to a string" do
+        -> { "hello world".rstrip(100)       }.should.raise(TypeError)
+        -> { "hello world".rstrip([])        }.should.raise(TypeError)
+        -> { "hello world".rstrip(mock('x')) }.should.raise(TypeError)
+      end
+
+      it "returns String instances when called on a subclass" do
+        StringSpecs::MyString.new("oh no!!!").rstrip("!").should.instance_of?(String)
+      end
+
+      it "returns a String in the same encoding as self" do
+        "hello".encode("US-ASCII").rstrip("o").encoding.should == Encoding::US_ASCII
+      end
+
+      it "raises an Encoding::CompatibilityError when the encodings are incompatible" do
+        -> { "hello".rstrip("e".encode("UTF-16LE")) }.should.raise(Encoding::CompatibilityError)
+        -> { "hello".encode("UTF-16LE").rstrip("e") }.should.raise(Encoding::CompatibilityError)
+      end
+    end
+  end
 end
 
 describe "String#rstrip!" do

--- a/spec/ruby/core/string/squeeze_spec.rb
+++ b/spec/ruby/core/string/squeeze_spec.rb
@@ -13,6 +13,7 @@ describe "String#squeeze" do
   it "only squeezes chars that are in the intersection of all sets given" do
     "woot squeeze cheese".squeeze("eost", "queo").should == "wot squeze chese"
     "  now   is  the".squeeze(" ").should == " now is the"
+    "hello".squeeze("").should == "hello"
   end
 
   it "negates sets starting with ^" do
@@ -49,13 +50,13 @@ describe "String#squeeze" do
     "AABBCCaabbcc[[]]".squeeze("A-a").should == "ABCabbcc[]"
   end
 
-  it "raises an ArgumentError when the parameter is out of sequence" do
+  it "raises an ArgumentError when the sequence is invalid" do
     s = "--subbookkeeper--"
     -> { s.squeeze("e-b") }.should.raise(ArgumentError)
     -> { s.squeeze("^e-b") }.should.raise(ArgumentError)
   end
 
-  it "tries to convert each set arg to a string using to_str" do
+  it "tries to convert each argument to a string using to_str" do
     other_string = mock('lo')
     other_string.should_receive(:to_str).and_return("lo")
 
@@ -70,10 +71,22 @@ describe "String#squeeze" do
     "yellow moon".encode("US-ASCII").squeeze("a").encoding.should == Encoding::US_ASCII
   end
 
-  it "raises a TypeError when one set arg can't be converted to a string" do
+  it "raises a TypeError when an argument can't be converted to a string" do
     -> { "hello world".squeeze([])        }.should.raise(TypeError)
     -> { "hello world".squeeze(Object.new)}.should.raise(TypeError)
     -> { "hello world".squeeze(mock('x')) }.should.raise(TypeError)
+  end
+
+  it "respects backslash for escaping" do
+    "aa--bb".squeeze("a\\-b").should == "a-b"
+    "^^".squeeze("\\^").should == "^"
+    "\\\\".squeeze("\\\\").should == "\\"
+  end
+
+  it "squeezes multibyte characters" do
+    "\u{56db}\u{56db}\u{6708}\u{6708}".squeeze("\u{6708}").should == "\u{56db}\u{56db}\u{6708}"
+    "\u{56db}\u{56db}\u{6708}\u{6708}".squeeze("\u{56db}").should == "\u{56db}\u{6708}\u{6708}"
+    "\u{56db}\u{56db}\u{6708}\u{6708}".squeeze("\u{56db}\u{6708}").should == "\u{56db}\u{6708}"
   end
 
   it "returns String instances when called on a subclass" do

--- a/spec/ruby/core/string/squeeze_spec.rb
+++ b/spec/ruby/core/string/squeeze_spec.rb
@@ -92,6 +92,11 @@ describe "String#squeeze" do
   it "returns String instances when called on a subclass" do
     StringSpecs::MyString.new("oh no!!!").squeeze("!").should.instance_of?(String)
   end
+
+  it "raises an Encoding::CompatibilityError when the encodings are incompatible" do
+    -> { "hello".squeeze("e".encode("UTF-16LE")) }.should.raise(Encoding::CompatibilityError)
+    -> { "hello".encode("UTF-16LE").squeeze("e") }.should.raise(Encoding::CompatibilityError)
+  end
 end
 
 describe "String#squeeze!" do

--- a/spec/ruby/core/string/strip_spec.rb
+++ b/spec/ruby/core/string/strip_spec.rb
@@ -15,6 +15,81 @@ describe "String#strip" do
   it "returns a copy of self without leading and trailing NULL bytes and whitespace" do
     " \x00 goodbye \x00 ".strip.should == "goodbye"
   end
+
+  ruby_version_is "4.0" do
+    context "when given character selectors arguments" do
+      it "removes leading and trailing characters in the intersection of sets removed" do
+        "  hello  ".strip(" ").should == "hello"
+        "llo".strip("lo", "l").should == "o"
+        "llo".strip("o", "lo").should == "ll"
+        "hello".strip("ho", "h").should == "ello"
+        "hell yeah".strip("").should == "hell yeah"
+      end
+
+      it "negates sets starting with ^" do
+        "ello".strip("aeiou", "^e").should == "ell"
+        "hello".strip("^o").should == "o"
+      end
+
+      it "removes leading and trailing characters in a sequence" do
+        "hello".strip("l-o").should == "he"
+        "hello".strip("e-h").should == "llo"
+        "hel-lo".strip("h-").should == "el-lo"
+        "hel-lo".strip("-o").should == "hel-l"
+        "abcdefgh".strip("a-ce-fh").should == "defg"
+        "abcdefgh".strip("he-fa-c").should == "defg"
+        "abcdefgh".strip("e-fha-c").should == "defg"
+        "abcde".strip("ac-e").should == "b"
+        "abcde".strip("^ac-e").should == "abcde"
+      end
+
+      it "removes leading and trailing multibyte characters" do
+        "四月".strip("月").should == "四"
+        "四月".strip("四").should == "月"
+        "哥哥我倒".strip("哥").should == "我倒"
+      end
+
+      it "respects backslash for escaping" do
+        "a-b".strip("a\\-b").should == ""
+        "^".strip("\\^").should == ""
+        "\\".strip("\\\\").should == ""
+      end
+
+      it "raises an ArgumentError when the sequence is invalid" do
+        -> { "hello".strip("h-e") }.should.raise(ArgumentError)
+        -> { "hello".strip("^h-e") }.should.raise(ArgumentError)
+      end
+
+      it "tries to convert each argument to a string using to_str" do
+        other_string = mock('h')
+        other_string.should_receive(:to_str).and_return("h")
+
+        other_string2 = mock('he')
+        other_string2.should_receive(:to_str).and_return("he")
+
+        "hello world".strip(other_string, other_string2).should == "ello world"
+      end
+
+      it "raises a TypeError when an argument can't be converted to a string" do
+        -> { "hello world".strip(100)       }.should.raise(TypeError)
+        -> { "hello world".strip([])        }.should.raise(TypeError)
+        -> { "hello world".strip(mock('x')) }.should.raise(TypeError)
+      end
+
+      it "returns String instances when called on a subclass" do
+        StringSpecs::MyString.new("oh no!!!").strip("!").should.instance_of?(String)
+      end
+
+      it "returns a String in the same encoding as self" do
+        "hello".encode("US-ASCII").strip("h").encoding.should == Encoding::US_ASCII
+      end
+
+      it "raises an Encoding::CompatibilityError when the encodings are incompatible" do
+        -> { "hello".strip("e".encode("UTF-16LE")) }.should.raise(Encoding::CompatibilityError)
+        -> { "hello".encode("UTF-16LE").strip("e") }.should.raise(Encoding::CompatibilityError)
+      end
+    end
+  end
 end
 
 describe "String#strip!" do
@@ -23,21 +98,45 @@ describe "String#strip!" do
     a.strip!.should.equal?(a)
     a.should == "hello"
 
-    a = "\tgoodbye\r\v\n"
-    a.strip!
-    a.should == "goodbye"
+    ruby_version_is "4.0" do
+      a = "---goodbye---"
+      a.strip!("-")
+      a.should == "goodbye"
+    end
   end
 
   it "returns nil if no modifications where made" do
     a = "hello"
     a.strip!.should == nil
     a.should == "hello"
+
+    ruby_version_is "4.0" do
+      a = "hello"
+      a.strip!("-").should == nil
+      a.should == "hello"
+    end
   end
 
   it "makes a string empty if it is only whitespace" do
-    "".strip!.should == nil
-    " ".strip.should == ""
-    "  ".strip.should == ""
+    a = ""
+    a.strip!
+    a.should == ""
+
+    a = "   "
+    a.strip!
+    a.should == ""
+  end
+
+  ruby_version_is "4.0" do
+    it "makes a string empty if all characters match given character selectors" do
+      a = ""
+      a.strip!("-")
+      a.should == ""
+
+      a = "----"
+      a.strip!("-")
+      a.should == ""
+    end
   end
 
   it "removes leading and trailing NULL bytes and whitespace" do
@@ -48,6 +147,9 @@ describe "String#strip!" do
 
   it "raises a FrozenError on a frozen instance that is modified" do
     -> { "  hello  ".freeze.strip! }.should.raise(FrozenError)
+    ruby_version_is "4.0" do
+      -> { "  hello  ".freeze.strip!("-") }.should.raise(FrozenError)
+    end
   end
 
   # see #1552

--- a/spec/ruby/core/string/tr_s_spec.rb
+++ b/spec/ruby/core/string/tr_s_spec.rb
@@ -16,6 +16,9 @@ describe "String#tr_s" do
     "123456789".tr_s("2-5", "abcdefg").should == "1abcd6789"
     "hello ^--^".tr_s("e-", "__").should == "h_llo ^_^"
     "hello ^--^".tr_s("---", "_").should == "hello ^_^"
+    "hello ^--^".tr_s("-e", "_a").should == "hallo ^_^"
+    "hel-001122".tr_s("--2", "a-f").should == "heladef"
+    "hel-(())".tr_s("(--", "a-f").should == "helfab"
   end
 
   it "accepts c1-c1 notation to denote range of one character" do
@@ -130,6 +133,16 @@ describe "String#tr_s" do
 
   it "returns a String in the same encoding as self" do
     "hello".encode("US-ASCII").tr_s("l", "r").encoding.should == Encoding::US_ASCII
+  end
+
+  it "raises an Encoding::CompatibilityError when the encodings are incompatible" do
+    -> { "hello".tr_s("e".encode("UTF-16LE"), "a") }.should.raise(Encoding::CompatibilityError)
+    -> { "hello".encode("UTF-16LE").tr_s("e", "a") }.should.raise(Encoding::CompatibilityError)
+  end
+
+  it "deletes the characters in from_str and does not squeeze the result if to_str is empty" do
+    "hello".tr_s("el", "").should == "ho"
+    "hellooo".tr_s("el", "").should == "hooo"
   end
 end
 

--- a/spec/ruby/core/string/tr_s_spec.rb
+++ b/spec/ruby/core/string/tr_s_spec.rb
@@ -29,6 +29,26 @@ describe "String#tr_s" do
     "this".tr_s("this", "x").should == "x"
   end
 
+  it "raises an ArgumentError when given wrong number of arguments" do
+    -> { "hello".tr_s }.should.raise(ArgumentError)
+    -> { "hello".tr_s("a") }.should.raise(ArgumentError)
+    -> { "hello".tr_s("a", "b", "c") }.should.raise(ArgumentError)
+  end
+
+  it "raises an ArgumentError when the replacement contains a descending range" do
+    -> { "hello".tr_s("a-y", "z-b") }.should.raise(ArgumentError)
+  end
+
+  it "raises an ArgumentError when the source contains a descending range" do
+    -> { "hello".tr_s("l-a", "z") }.should.raise(ArgumentError)
+  end
+
+  it "returns self (or a copy) when from_string or to_string is empty" do
+    "hello".tr_s("", "a").should == "hello"
+    "hello".tr_s("a", "").should == "hello"
+    "hello".tr_s("", "").should == "hello"
+  end
+
   it "translates chars not in from_string when it starts with a ^" do
     "hello".tr_s('^aeiou', '*').should == "*e*o"
     "123456789".tr_s("^345", "abc").should == "c345c"
@@ -43,7 +63,7 @@ describe "String#tr_s" do
     "hello ^-^".tr_s("^---l-o", "x").should == "xllox-x"
   end
 
-  it "tries to convert from_str and to_str to strings using to_str" do
+  it "tries to convert each argument to a string using to_str" do
     from_str = mock('ab')
     from_str.should_receive(:to_str).and_return("ab")
 
@@ -97,7 +117,20 @@ describe "String#tr_s" do
     str.tr_s(a, b).should == "椎名深夏"
   end
 
+  it "respects backslash for escaping" do
+    "aa--bb".tr_s("a\\-b", "123").should == "123"
+    "^^".tr_s("\\^", "1").should == "1"
+    "\\\\".tr_s("\\\\", "1").should == "1"
+  end
 
+  it "raises a TypeError when an argument can't be converted to a string" do
+    -> { "hello".tr_s(100, "a") }.should.raise(TypeError)
+    -> { "hello".tr_s("a", [])  }.should.raise(TypeError)
+  end
+
+  it "returns a String in the same encoding as self" do
+    "hello".encode("US-ASCII").tr_s("l", "r").encoding.should == Encoding::US_ASCII
+  end
 end
 
 describe "String#tr_s!" do

--- a/spec/ruby/core/string/tr_spec.rb
+++ b/spec/ruby/core/string/tr_spec.rb
@@ -29,12 +29,24 @@ describe "String#tr" do
     "hello".tr("a-z", "A-H.").should == "HE..."
   end
 
-  it "raises an ArgumentError a descending range in the replacement as containing just the start character" do
+  it "raises an ArgumentError when given wrong number of arguments" do
+    -> { "hello".tr }.should.raise(ArgumentError)
+    -> { "hello".tr("a") }.should.raise(ArgumentError)
+    -> { "hello".tr("a", "b", "c") }.should.raise(ArgumentError)
+  end
+
+  it "raises an ArgumentError when the replacement contains a descending range" do
     -> { "hello".tr("a-y", "z-b") }.should.raise(ArgumentError)
   end
 
-  it "raises an ArgumentError a descending range in the source as empty" do
+  it "raises an ArgumentError when the source contains a descending range" do
     -> { "hello".tr("l-a", "z") }.should.raise(ArgumentError)
+  end
+
+  it "returns self (or a copy) when from_string or to_string is empty" do
+    "hello".tr("", "a").should == "hello"
+    "hello".tr("a", "").should == "hello"
+    "hello".tr("", "").should == "hello"
   end
 
   it "translates chars not in from_string when it starts with a ^" do
@@ -55,7 +67,7 @@ describe "String#tr" do
     "hello".tr("helo", "1212").should == "12112"
   end
 
-  it "tries to convert from_str and to_str to strings using to_str" do
+  it "tries to convert each argument to a string using to_str" do
     from_str = mock('ab')
     from_str.should_receive(:to_str).and_return("ab")
 
@@ -65,7 +77,7 @@ describe "String#tr" do
     "bla".tr(from_str, to_str).should == "BlA"
   end
 
-  it "returns Stringinstances when called on a subclass" do
+  it "returns String instances when called on a subclass" do
     StringSpecs::MyString.new("hello").tr("e", "a").should.instance_of?(String)
   end
 
@@ -91,6 +103,21 @@ describe "String#tr" do
     a = "\u0080\u0082\u0083\u0084\u0085\u0086\u0087\u0088\u0089\u008A\u008B\u008C\u008E\u0091\u0092\u0093\u0094\u0095\u0096\u0097\u0098\u0099\u009A\u009B\u009C\u009E\u009F"
     b = "€‚ƒ„…†‡ˆ‰Š‹ŒŽ‘’“”•–—˜™š›œžŸ"
     str.tr(a, b).should == "椎名深夏"
+  end
+
+  it "respects backslash for escaping" do
+    "a-b".tr("a\\-b", "123").should == "123"
+    "^".tr("\\^", "1").should == "1"
+    "\\".tr("\\\\", "1").should == "1"
+  end
+
+  it "raises a TypeError when an argument can't be converted to a string" do
+    -> { "hello".tr(100, "a") }.should.raise(TypeError)
+    -> { "hello".tr("a", [])  }.should.raise(TypeError)
+  end
+
+  it "returns a String in the same encoding as self" do
+    "hello".encode("US-ASCII").tr("l", "r").encoding.should == Encoding::US_ASCII
   end
 
 end

--- a/spec/ruby/core/string/tr_spec.rb
+++ b/spec/ruby/core/string/tr_spec.rb
@@ -15,6 +15,9 @@ describe "String#tr" do
     "123456789".tr("2-5","abcdefg").should == "1abcd6789"
     "hello ^-^".tr("e-", "__").should == "h_llo ^_^"
     "hello ^-^".tr("---", "_").should == "hello ^_^"
+    "hello ^-^".tr("-e", "_a").should == "hallo ^_^"
+    "hel-012".tr("--2", "a-f").should == "heladef"
+    "hel-()".tr("(--", "a-f").should == "helfab"
   end
 
   it "accepts c1-c1 notation to denote range of one character" do
@@ -120,6 +123,14 @@ describe "String#tr" do
     "hello".encode("US-ASCII").tr("l", "r").encoding.should == Encoding::US_ASCII
   end
 
+  it "raises an Encoding::CompatibilityError when the encodings are incompatible" do
+    -> { "hello".tr("e".encode("UTF-16LE"), "a") }.should.raise(Encoding::CompatibilityError)
+    -> { "hello".encode("UTF-16LE").tr("e", "a") }.should.raise(Encoding::CompatibilityError)
+  end
+
+  it "deletes the characters in from_str if to_str is empty" do
+    "hello".tr("el", "").should == "ho"
+  end
 end
 
 describe "String#tr!" do

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -1417,80 +1417,107 @@ public abstract class StringNodes {
         }
     }
 
-    @CoreMethod(names = "rstrip!", raiseIfNotMutableSelf = true)
+    @CoreMethod(names = "rstrip!", raiseIfNotMutableSelf = true, rest = true)
     @ImportStatic(StringGuards.class)
     public abstract static class RstripBangNode extends CoreMethodArrayArgumentsNode {
 
         @Specialization(guards = "string.tstring.isEmpty()")
-        Object rstripBangEmptyString(RubyString string) {
+        Object rstripBangEmptyString(RubyString string, Object[] args) {
             return nil;
         }
 
-        @Specialization(guards = "!string.tstring.isEmpty()")
-        static Object rstripBangNonEmptyString(RubyString string,
-                @Cached RubyStringLibrary libString,
-                @Cached TruffleString.CreateBackwardCodePointIteratorNode createBackwardCodePointIteratorNode,
-                @Cached TruffleStringIterator.PreviousNode previousNode,
-                @Cached InlinedBranchProfile allWhitespaceProfile,
-                @Cached InlinedBranchProfile nonSpaceCodePointProfile,
-                @Cached InlinedBranchProfile badCodePointProfile,
-                @Cached TruffleString.SubstringByteIndexNode substringNode,
+        @Specialization(guards = { "!string.tstring.isEmpty()", "noArguments(args)" })
+        static Object rstripZeroArgs(RubyString string, Object[] args,
+                @Cached @Exclusive RubyStringLibrary libString,
+                @Cached @Exclusive SingleByteOptimizableNode singleByteOptimizableNode,
+                @Cached @Shared TruffleString.GetInternalByteArrayNode byteArrayNode,
+                @Cached @Shared TruffleString.SubstringByteIndexNode substringNode,
+                @Cached @Exclusive InlinedConditionProfile singleByteProfile,
                 @Cached @Exclusive InlinedConditionProfile noopProfile,
+                @Cached @Exclusive InlinedConditionProfile emptyStringProfile,
                 @Bind Node node) {
             var tstring = string.tstring;
             var encoding = libString.getEncoding(node, string);
-            var tencoding = encoding.tencoding;
 
-            var iterator = createBackwardCodePointIteratorNode.execute(tstring, tencoding,
-                    ErrorHandling.RETURN_NEGATIVE);
-            int codePoint = previousNode.execute(iterator, tencoding);
-
-            // Check the last code point to see if it's broken. In the case of strings without trailing spaces,
-            // this check can avoid having to compile the while loop.
-            if (codePoint == -1) {
-                badCodePointProfile.enter(node);
-                throw new RaiseException(getContext(node),
-                        coreExceptions(node).argumentErrorInvalidByteSequence(encoding, node));
+            int endIndex;
+            if (singleByteProfile.profile(node,
+                    StringGuards.isSingleByteOptimizable(node, tstring, encoding, singleByteOptimizableNode))) {
+                var byteArray = byteArrayNode.execute(tstring, encoding.tencoding);
+                endIndex = StringSupport.singleByteRstripEndIndex(byteArray, null);
+            } else {
+                endIndex = StringSupport.multiByteRstripEndIndex(tstring, encoding, null, null, node);
             }
 
-            // Check the last code point to see if it's a space. In the case of strings without trailing spaces,
-            // this check can avoid having to compile the while loop.
-            if (noopProfile.profile(node, !StringSupport.isAsciiSpaceOrNull(codePoint))) {
+            return trimTrailing(node, string, tstring, encoding.tencoding, endIndex, substringNode,
+                    noopProfile, emptyStringProfile);
+        }
+
+        @Specialization(guards = { "!string.tstring.isEmpty()", "!noArguments(args)" })
+        static Object rstripWithSelectors(RubyString string, Object[] args,
+                @Cached @Exclusive RubyStringLibrary libString,
+                @Cached @Exclusive SingleByteOptimizableNode singleByteOptimizableNode,
+                @Cached @Shared TruffleString.GetInternalByteArrayNode byteArrayNode,
+                @Cached @Shared TruffleString.SubstringByteIndexNode substringNode,
+                @Cached @Exclusive ToStrNode toStrNode,
+                @Cached @Exclusive CheckStringEncodingNode checkEncodingNode,
+                @Cached @Exclusive InlinedConditionProfile singleByteProfile,
+                @Cached @Exclusive InlinedConditionProfile noopProfile,
+                @Cached @Exclusive InlinedConditionProfile emptyStringProfile,
+                @Bind Node node) {
+            var tstring = string.tstring;
+            var encoding = libString.getEncoding(node, string);
+
+            var squeeze = new boolean[StringSupport.TRANS_SIZE + 1];
+            StringSupport.TrTables tables = setupTables(node, args, tstring, encoding, squeeze, libString,
+                    toStrNode, checkEncodingNode);
+
+            int endIndex;
+            if (singleByteProfile.profile(node,
+                    StringGuards.isSingleByteOptimizable(node, tstring, encoding, singleByteOptimizableNode))) {
+                var byteArray = byteArrayNode.execute(tstring, encoding.tencoding);
+                endIndex = StringSupport.singleByteRstripEndIndex(byteArray, squeeze);
+            } else {
+                endIndex = StringSupport.multiByteRstripEndIndex(tstring, encoding, squeeze, tables, node);
+            }
+
+            return trimTrailing(node, string, tstring, encoding.tencoding, endIndex, substringNode,
+                    noopProfile, emptyStringProfile);
+        }
+
+        // Trims trailing characters from the string up to endIndex.
+        private static Object trimTrailing(Node node, RubyString string, AbstractTruffleString tstring,
+                TruffleString.Encoding tencoding, int endIndex,
+                TruffleString.SubstringByteIndexNode substringNode,
+                InlinedConditionProfile noopProfile,
+                InlinedConditionProfile emptyStringProfile) {
+            if (noopProfile.profile(node, endIndex == -1)) {
                 return nil;
             }
 
-            while (iterator.hasPrevious()) {
-                int byteIndex = iterator.getByteIndex();
-                codePoint = previousNode.execute(iterator, tencoding);
-
-                if (codePoint == -1) {
-                    badCodePointProfile.enter(node);
-                    throw new RaiseException(getContext(node),
-                            coreExceptions(node).argumentErrorInvalidByteSequence(encoding, node));
-                }
-
-                if (!StringSupport.isAsciiSpaceOrNull(codePoint)) {
-                    nonSpaceCodePointProfile.enter(node);
-                    string.setTString(makeSubstring(substringNode, tstring, tencoding, byteIndex));
-
-                    return string;
-                }
+            if (emptyStringProfile.profile(node, endIndex == 0)) {
+                string.setTString(tencoding.getEmpty());
+            } else {
+                string.setTString(substringNode.execute(tstring, 0, endIndex, tencoding, true));
             }
-
-            // If we've made it this far, the string must consist only of whitespace. Otherwise, we would have exited
-            // early in the first code point check or in the iterator when the first non-space character was encountered.
-            allWhitespaceProfile.enter(node);
-            string.setTString(tencoding.getEmpty());
-
             return string;
         }
 
-        private static AbstractTruffleString makeSubstring(TruffleString.SubstringByteIndexNode substringNode,
-                AbstractTruffleString base, TruffleString.Encoding encoding,
-                int byteEnd) {
-            return substringNode.execute(base, 0, byteEnd, encoding, true);
-        }
+    }
 
+    // Builds the character lookup tables and squeeze flags for selector arguments after validating encoding compatibility.
+    private static StringSupport.TrTables setupTables(Node node, Object[] args,
+            AbstractTruffleString tstring, RubyEncoding encoding, boolean[] squeeze,
+            RubyStringLibrary libString, ToStrNode toStrNode, CheckStringEncodingNode checkEncodingNode) {
+        StringSupport.TrTables tables = null;
+        for (int i = 0; i < args.length; i++) {
+            Object arg = toStrNode.execute(node, args[i]);
+            var argTString = libString.getTString(node, arg);
+            var argEncoding = libString.getEncoding(node, arg);
+            var negotiatedEncoding = checkEncodingNode.execute(node, tstring, encoding, argTString, argEncoding);
+            tables = StringSupport.trSetupTable(argTString, argEncoding, squeeze, tables, i == 0,
+                    negotiatedEncoding.jcoding, node);
+        }
+        return tables;
     }
 
     @CoreMethod(names = "dump")

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -1293,79 +1293,91 @@ public abstract class StringNodes {
         }
     }
 
-    @CoreMethod(names = "lstrip!", raiseIfNotMutableSelf = true)
+    @CoreMethod(names = "lstrip!", raiseIfNotMutableSelf = true, rest = true)
     @ImportStatic(StringGuards.class)
     public abstract static class LstripBangNode extends CoreMethodArrayArgumentsNode {
 
         @Specialization(guards = "string.tstring.isEmpty()")
-        Object lstripBangEmptyString(RubyString string) {
+        Object lstripBangEmptyString(RubyString string, Object[] args) {
             return nil;
         }
 
-        @Specialization(guards = "!string.tstring.isEmpty()")
-        static Object lstripBangSingleByte(RubyString string,
-                @Cached RubyStringLibrary libString,
-                @Cached CreateCodePointIteratorNode createCodePointIteratorNode,
-                @Cached TruffleString.SubstringByteIndexNode substringNode,
-                @Cached TruffleStringIterator.NextNode nextNode,
-                @Cached InlinedBranchProfile allWhitespaceProfile,
-                @Cached InlinedBranchProfile nonSpaceCodePointProfile,
-                @Cached InlinedBranchProfile badCodePointProfile,
-                @Cached InlinedConditionProfile noopProfile,
+        @Specialization(guards = { "!string.tstring.isEmpty()", "noArguments(args)" })
+        static Object lstripZeroArgs(RubyString string, Object[] args,
+                @Cached @Exclusive RubyStringLibrary libString,
+                @Cached @Exclusive SingleByteOptimizableNode singleByteOptimizableNode,
+                @Cached @Shared TruffleString.GetInternalByteArrayNode byteArrayNode,
+                @Cached @Shared TruffleString.SubstringByteIndexNode substringNode,
+                @Cached @Exclusive InlinedConditionProfile singleByteProfile,
+                @Cached @Exclusive InlinedConditionProfile noopProfile,
+                @Cached @Exclusive InlinedConditionProfile emptyStringProfile,
                 @Bind Node node) {
             var tstring = string.tstring;
             var encoding = libString.getEncoding(node, string);
-            var tencoding = encoding.tencoding;
 
-            var iterator = createCodePointIteratorNode.execute(tstring, tencoding, ErrorHandling.RETURN_NEGATIVE);
-            int codePoint = nextNode.execute(iterator, tencoding);
-
-            // Check the first code point to see if it's broken. In the case of strings without leading spaces,
-            // this check can avoid having to compile the while loop.
-            if (codePoint == -1) {
-                badCodePointProfile.enter(node);
-                throw new RaiseException(getContext(node),
-                        coreExceptions(node).argumentErrorInvalidByteSequence(encoding, node));
+            int startIndex;
+            if (singleByteProfile.profile(node,
+                    StringGuards.isSingleByteOptimizable(node, tstring, encoding, singleByteOptimizableNode))) {
+                var byteArray = byteArrayNode.execute(tstring, encoding.tencoding);
+                startIndex = StringSupport.singleByteLstripStartIndex(byteArray, null);
+            } else {
+                startIndex = StringSupport.multiByteLstripStartIndex(tstring, encoding, null, null, node);
             }
 
-            // Check the first code point to see if it's a space. In the case of strings without leading spaces,
-            // this check can avoid having to compile the while loop.
-            if (noopProfile.profile(node, !StringSupport.isAsciiSpaceOrNull(codePoint))) {
+            return trimLeading(node, string, tstring, encoding.tencoding, startIndex, substringNode,
+                    noopProfile, emptyStringProfile);
+        }
+
+        @Specialization(guards = { "!string.tstring.isEmpty()", "!noArguments(args)" })
+        static Object lstripWithSelectors(RubyString string, Object[] args,
+                @Cached @Exclusive RubyStringLibrary libString,
+                @Cached @Exclusive SingleByteOptimizableNode singleByteOptimizableNode,
+                @Cached @Shared TruffleString.GetInternalByteArrayNode byteArrayNode,
+                @Cached @Shared TruffleString.SubstringByteIndexNode substringNode,
+                @Cached @Exclusive ToStrNode toStrNode,
+                @Cached @Exclusive CheckStringEncodingNode checkEncodingNode,
+                @Cached @Exclusive InlinedConditionProfile singleByteProfile,
+                @Cached @Exclusive InlinedConditionProfile noopProfile,
+                @Cached @Exclusive InlinedConditionProfile emptyStringProfile,
+                @Bind Node node) {
+            var tstring = string.tstring;
+            var encoding = libString.getEncoding(node, string);
+
+            var squeeze = new boolean[StringSupport.TRANS_SIZE + 1];
+            StringSupport.TrTables tables = setupTables(node, args, tstring, encoding, squeeze, libString,
+                    toStrNode, checkEncodingNode);
+
+            int startIndex;
+            if (singleByteProfile.profile(node,
+                    StringGuards.isSingleByteOptimizable(node, tstring, encoding, singleByteOptimizableNode))) {
+                var byteArray = byteArrayNode.execute(tstring, encoding.tencoding);
+                startIndex = StringSupport.singleByteLstripStartIndex(byteArray, squeeze);
+            } else {
+                startIndex = StringSupport.multiByteLstripStartIndex(tstring, encoding, squeeze, tables, node);
+            }
+
+            return trimLeading(node, string, tstring, encoding.tencoding, startIndex, substringNode,
+                    noopProfile, emptyStringProfile);
+        }
+
+        // Trims leading characters from the string up to startIndex.
+        private static Object trimLeading(Node node, RubyString string, AbstractTruffleString tstring,
+                TruffleString.Encoding tencoding, int startIndex,
+                TruffleString.SubstringByteIndexNode substringNode,
+                InlinedConditionProfile noopProfile,
+                InlinedConditionProfile emptyStringProfile) {
+            if (noopProfile.profile(node, startIndex == -1)) {
                 return nil;
             }
 
-            while (iterator.hasNext()) {
-                int byteIndex = iterator.getByteIndex();
-                codePoint = nextNode.execute(iterator, tencoding);
-
-                if (codePoint == -1) {
-                    badCodePointProfile.enter(node);
-                    throw new RaiseException(getContext(node),
-                            coreExceptions(node).argumentErrorInvalidByteSequence(encoding, node));
-                }
-
-                if (!StringSupport.isAsciiSpaceOrNull(codePoint)) {
-                    nonSpaceCodePointProfile.enter(node);
-                    string.setTString(makeSubstring(substringNode, tstring, tencoding, byteIndex));
-
-                    return string;
-                }
+            int totalLength = tstring.byteLength(tencoding);
+            if (emptyStringProfile.profile(node, startIndex == totalLength)) {
+                string.setTString(tencoding.getEmpty());
+            } else {
+                int substringByteLength = totalLength - startIndex;
+                string.setTString(substringNode.execute(tstring, startIndex, substringByteLength, tencoding, true));
             }
-
-            // If we've made it this far, the string must consist only of whitespace. Otherwise, we would have exited
-            // early in the first code point check or in the iterator when the first non-space character was encountered.
-            allWhitespaceProfile.enter(node);
-            string.setTString(tencoding.getEmpty());
-
             return string;
-        }
-
-        private static AbstractTruffleString makeSubstring(TruffleString.SubstringByteIndexNode substringNode,
-                AbstractTruffleString base, TruffleString.Encoding encoding,
-                int byteOffset) {
-            int substringByteLength = base.byteLength(encoding) - byteOffset;
-
-            return substringNode.execute(base, byteOffset, substringByteLength, encoding, true);
         }
 
     }

--- a/src/main/java/org/truffleruby/core/string/StringSupport.java
+++ b/src/main/java/org/truffleruby/core/string/StringSupport.java
@@ -37,9 +37,11 @@ import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.strings.AbstractTruffleString;
 import com.oracle.truffle.api.strings.InternalByteArray;
 import com.oracle.truffle.api.strings.TruffleString;
+import com.oracle.truffle.api.strings.TruffleString.CreateBackwardCodePointIteratorNode;
 import com.oracle.truffle.api.strings.TruffleString.CreateCodePointIteratorNode;
 import com.oracle.truffle.api.strings.TruffleString.ErrorHandling;
 import com.oracle.truffle.api.strings.TruffleString.FromByteArrayNode;
+import com.oracle.truffle.api.strings.TruffleStringIterator;
 import org.graalvm.collections.Pair;
 import org.graalvm.shadowed.org.jcodings.Config;
 import org.graalvm.shadowed.org.jcodings.Encoding;
@@ -1331,6 +1333,65 @@ public final class StringSupport {
         }
 
         return false;
+    }
+
+    public static int singleByteRstripEndIndex(InternalByteArray byteArray, boolean[] squeeze) {
+        final int len = byteArray.getLength();
+        if (len == 0) {
+            return -1;
+        }
+
+        final int lastByte = byteArray.get(len - 1) & 0xff;
+        if (squeeze != null ? !squeeze[lastByte] : !isAsciiSpaceOrNull(lastByte)) {
+            return -1;
+        }
+
+        int i = len - 2;
+        while (i >= 0) {
+            final int b = byteArray.get(i) & 0xff;
+            if (squeeze != null ? !squeeze[b] : !isAsciiSpaceOrNull(b)) {
+                return i + 1;
+            }
+            i--;
+        }
+
+        return 0;
+    }
+
+    @TruffleBoundary
+    public static int multiByteRstripEndIndex(AbstractTruffleString tstring, RubyEncoding encoding,
+            boolean[] squeeze, TrTables tables, Node node) {
+        final var tencoding = encoding.tencoding;
+        var iterator = CreateBackwardCodePointIteratorNode.getUncached().execute(tstring, tencoding,
+                ErrorHandling.RETURN_NEGATIVE);
+        int codePoint = TruffleStringIterator.PreviousNode.getUncached().execute(iterator, tencoding);
+
+        if (codePoint == -1) {
+            throw new RaiseException(RubyContext.get(node),
+                    RubyContext.get(node).getCoreExceptions().argumentErrorInvalidByteSequence(encoding, node));
+        }
+
+        boolean matches = squeeze != null ? trFind(codePoint, squeeze, tables) : isAsciiSpaceOrNull(codePoint);
+        if (!matches) {
+            return -1;
+        }
+
+        while (iterator.hasPrevious()) {
+            int byteIndex = iterator.getByteIndex();
+            codePoint = TruffleStringIterator.PreviousNode.getUncached().execute(iterator, tencoding);
+
+            if (codePoint == -1) {
+                throw new RaiseException(RubyContext.get(node),
+                        RubyContext.get(node).getCoreExceptions().argumentErrorInvalidByteSequence(encoding, node));
+            }
+
+            matches = squeeze != null ? trFind(codePoint, squeeze, tables) : isAsciiSpaceOrNull(codePoint);
+            if (!matches) {
+                return byteIndex;
+            }
+        }
+
+        return 0;
     }
 
     // region Case Mapping Methods

--- a/src/main/java/org/truffleruby/core/string/StringSupport.java
+++ b/src/main/java/org/truffleruby/core/string/StringSupport.java
@@ -1394,6 +1394,65 @@ public final class StringSupport {
         return 0;
     }
 
+    public static int singleByteLstripStartIndex(InternalByteArray byteArray, boolean[] squeeze) {
+        final int len = byteArray.getLength();
+        if (len == 0) {
+            return -1;
+        }
+
+        final int firstByte = byteArray.get(0) & 0xff;
+        if (squeeze != null ? !squeeze[firstByte] : !isAsciiSpaceOrNull(firstByte)) {
+            return -1;
+        }
+
+        int i = 1;
+        while (i < len) {
+            final int b = byteArray.get(i) & 0xff;
+            if (squeeze != null ? !squeeze[b] : !isAsciiSpaceOrNull(b)) {
+                return i;
+            }
+            i++;
+        }
+
+        return len;
+    }
+
+    @TruffleBoundary
+    public static int multiByteLstripStartIndex(AbstractTruffleString tstring, RubyEncoding encoding,
+            boolean[] squeeze, TrTables tables, Node node) {
+        final var tencoding = encoding.tencoding;
+        var iterator = CreateCodePointIteratorNode.getUncached().execute(tstring, tencoding,
+                ErrorHandling.RETURN_NEGATIVE);
+        int codePoint = TruffleStringIterator.NextNode.getUncached().execute(iterator, tencoding);
+
+        if (codePoint == -1) {
+            throw new RaiseException(RubyContext.get(node),
+                    RubyContext.get(node).getCoreExceptions().argumentErrorInvalidByteSequence(encoding, node));
+        }
+
+        boolean matches = squeeze != null ? trFind(codePoint, squeeze, tables) : isAsciiSpaceOrNull(codePoint);
+        if (!matches) {
+            return -1;
+        }
+
+        while (iterator.hasNext()) {
+            int byteIndex = iterator.getByteIndex();
+            codePoint = TruffleStringIterator.NextNode.getUncached().execute(iterator, tencoding);
+
+            if (codePoint == -1) {
+                throw new RaiseException(RubyContext.get(node),
+                        RubyContext.get(node).getCoreExceptions().argumentErrorInvalidByteSequence(encoding, node));
+            }
+
+            matches = squeeze != null ? trFind(codePoint, squeeze, tables) : isAsciiSpaceOrNull(codePoint);
+            if (!matches) {
+                return byteIndex;
+            }
+        }
+
+        return tstring.byteLength(tencoding);
+    }
+
     // region Case Mapping Methods
 
     @TruffleBoundary

--- a/src/main/ruby/truffleruby/core/string.rb
+++ b/src/main/ruby/truffleruby/core/string.rb
@@ -307,9 +307,9 @@ class String
     [empty, empty.dup, Primitive.dup_as_string_instance(self)]
   end
 
-  def rstrip
+  def rstrip(*strings)
     str = Primitive.dup_as_string_instance(self)
-    str.rstrip! || str
+    str.rstrip!(*strings) || str
   end
 
   def scan(pattern, &block)

--- a/src/main/ruby/truffleruby/core/string.rb
+++ b/src/main/ruby/truffleruby/core/string.rb
@@ -358,14 +358,15 @@ class String
     str.squeeze!(*strings) || str
   end
 
-  def strip
+  def strip(*strings)
     str = Primitive.dup_as_string_instance(self)
-    str.strip! || str
+    str.strip!(*strings) || str
   end
 
-  def strip!
-    right = rstrip! # Process rstrip! first because it must perform an encoding compatibility check that lstrip! does not.
-    left = lstrip!
+  def strip!(*strings)
+    strings = strings.map { |s| Primitive.convert_with_to_str(s) } unless strings.empty?
+    right = rstrip!(*strings)
+    left = lstrip!(*strings)
     Primitive.nil?(left) && Primitive.nil?(right) ? nil : self
   end
 

--- a/src/main/ruby/truffleruby/core/string.rb
+++ b/src/main/ruby/truffleruby/core/string.rb
@@ -230,9 +230,9 @@ class String
   end
   alias_method :intern, :to_sym
 
-  def lstrip
+  def lstrip(*strings)
     str = Primitive.dup_as_string_instance(self)
-    str.lstrip! || str
+    str.lstrip!(*strings) || str
   end
 
   def oct


### PR DESCRIPTION
Issue #4231

> String#strip, strip!, lstrip, lstrip!, rstrip, and rstrip! are extended to accept *selectors arguments. [[Feature #21552](https://bugs.ruby-lang.org/issues/21552)]

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
