### PR TITLE
Fix issues with libcrypt and crypt()

### DIFF
--- a/mx.truffleruby/suite.py
+++ b/mx.truffleruby/suite.py
@@ -228,7 +228,7 @@ suite = {
             "ldflags": ["-pthread"],
             "os": {
                 "linux": {
-                    "ldlibs": ["-lrt", "-lcrypt"],
+                    "ldlibs": ["-lrt"],
                 },
                 "<others>": {
                 },

--- a/mx.truffleruby/suite.py
+++ b/mx.truffleruby/suite.py
@@ -228,7 +228,7 @@ suite = {
             "ldflags": ["-pthread"],
             "os": {
                 "linux": {
-                    "ldlibs": ["-lrt"],
+                    "ldlibs": ["-lrt", "-ldl"],
                 },
                 "<others>": {
                 },

--- a/src/main/c/truffleposix/posix_errno_wrappers.c.inc
+++ b/src/main/c/truffleposix/posix_errno_wrappers.c.inc
@@ -651,13 +651,11 @@ int tpe_unsetenv_native(int* errno_ptr, char* a) {
   return result;
 }
 
-#ifdef HAVE_CRYPT
 char* tpe_crypt(int* errno_ptr, char* a, char* b) {
   char* result = crypt(a, b);
   *errno_ptr = errno;
   return result;
 }
-#endif
 
 void* tpe_truffleposix_get_current_user_home(int* errno_ptr) {
   void* result = truffleposix_get_current_user_home();

--- a/src/main/c/truffleposix/posix_errno_wrappers.c.inc
+++ b/src/main/c/truffleposix/posix_errno_wrappers.c.inc
@@ -652,7 +652,7 @@ int tpe_unsetenv_native(int* errno_ptr, char* a) {
 }
 
 char* tpe_crypt(int* errno_ptr, char* a, char* b) {
-  char* result = crypt(a, b);
+  char* result = truffleposix_crypt(a, b);
   *errno_ptr = errno;
   return result;
 }

--- a/src/main/c/truffleposix/src/truffleposix.c
+++ b/src/main/c/truffleposix/src/truffleposix.c
@@ -37,10 +37,12 @@ SUCH DAMAGE.
 #include "ruby/config.h"
 
 #include <dirent.h>
+#include <dlfcn.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <grp.h>
 #include <poll.h>
+#include <pthread.h>
 #include <pwd.h>
 #include <signal.h>
 #include <spawn.h>
@@ -66,13 +68,41 @@ SUCH DAMAGE.
 #include <sys/sysmacros.h>
 #endif
 
-// Declare it instead of including libcrypt.h, since that's not available in Ubuntu 26.04 by default.
-// Critically, do not link to libcrypt, since they are not ABI compatible between Linux-es,
-// for example Ubuntu 26.04 has libcrypt.so.1.1.0 and Fedora 43 has libcrypt.so.2.0.0.
-// So this is basically the same as dlsym(RTLD_DEFAULT, "crypt")
-// or IOW calling crypt() directly with FFI, without a C wrapper,
-// which is what we did before and worked fine.
-char* crypt(const char *phrase, const char *setting);
+// Load libcrypt dynamically rather than linking at build time,
+// since libcrypt is not SONAME-compatible between Linux-es:
+// Ubuntu 26.04 has libcrypt.so.1.1.0 and Fedora 43 has libcrypt.so.2.0.0.
+typedef char* (*crypt_function)(const char *phrase, const char *setting);
+
+static pthread_once_t crypt_once = PTHREAD_ONCE_INIT;
+static crypt_function crypt_impl;
+
+static void truffleposix_resolve_crypt(void) {
+#ifdef __linux__
+  void *handle = dlopen("libcrypt.so", RTLD_LAZY | RTLD_LOCAL);
+  if (handle == NULL) {
+    handle = dlopen("libcrypt.so.2", RTLD_LAZY | RTLD_LOCAL);
+  }
+  if (handle == NULL) {
+    handle = dlopen("libcrypt.so.1", RTLD_LAZY | RTLD_LOCAL);
+  }
+#else
+  void *handle = RTLD_DEFAULT;
+#endif
+
+  if (handle != NULL) {
+    crypt_impl = (crypt_function) dlsym(handle, "crypt");
+  }
+}
+
+char* truffleposix_crypt(const char *phrase, const char *setting) {
+  pthread_once(&crypt_once, truffleposix_resolve_crypt);
+  if (crypt_impl == NULL) {
+    errno = ENOSYS;
+    return NULL;
+  }
+
+  return crypt_impl(phrase, setting);
+}
 
 // Birthtime is not supported by the standard POSIX stat(2) system call (or similar POSIX functions).
 // On Darwin, it is returned by stat(2) (along with other additional struct members)

--- a/src/main/c/truffleposix/src/truffleposix.c
+++ b/src/main/c/truffleposix/src/truffleposix.c
@@ -66,9 +66,13 @@ SUCH DAMAGE.
 #include <sys/sysmacros.h>
 #endif
 
-#ifdef HAVE_CRYPT_H
-#include <crypt.h>
-#endif
+// Declare it instead of including libcrypt.h, since that's not available in Ubuntu 26.04 by default.
+// Critically, do not link to libcrypt, since they are not ABI compatible between Linux-es,
+// for example Ubuntu 26.04 has libcrypt.so.1.1.0 and Fedora 43 has libcrypt.so.2.0.0.
+// So this is basically the same as dlsym(RTLD_DEFAULT, "crypt")
+// or IOW calling crypt() directly with FFI, without a C wrapper,
+// which is what we did before and worked fine.
+char* crypt(const char *phrase, const char *setting);
 
 // Birthtime is not supported by the standard POSIX stat(2) system call (or similar POSIX functions).
 // On Darwin, it is returned by stat(2) (along with other additional struct members)

--- a/src/main/java/org/truffleruby/extra/TrufflePosixNodes.java
+++ b/src/main/java/org/truffleruby/extra/TrufflePosixNodes.java
@@ -110,14 +110,8 @@ public abstract class TrufflePosixNodes {
                     context.getCoreExceptions().runtimeError("loading library while pre-initializing", currentNode));
         }
 
-        long address;
-        try {
-            address = lookupLibtruffleposix(language).find(nativeName.getString()).map(MemorySegment::address)
-                    .orElse(0L);
-        } catch (UnsatisfiedLinkError | IllegalArgumentException e) {
-            address = 0;
-        }
-
+        var libtruffleposix = lookupLibtruffleposix(language);
+        long address = libtruffleposix.find(nativeName.getString()).map(MemorySegment::address).orElse(0L);
         if (address == 0) {
             return Nil.INSTANCE;
         }

--- a/tool/generate-posix-functions.rb
+++ b/tool/generate-posix-functions.rb
@@ -169,7 +169,7 @@ attach_function :setenv, [:string, :string, :int], :int, method_name: :setenv_na
 attach_function :unsetenv, [:string], :int, method_name: :unsetenv_native
 
 # Other routines
-attach_function :crypt, [:string, :string], :string
+attach_function :truffleposix_crypt, [:string, :string], :string, method_name: :crypt
 attach_function :truffleposix_get_current_user_home, [], :pointer
 attach_function :truffleposix_get_user_home, [:string], :pointer
 attach_function :truffleposix_free, [:pointer], :void

--- a/tool/generate-posix-functions.rb
+++ b/tool/generate-posix-functions.rb
@@ -31,7 +31,6 @@ ruby_file = 'src/main/ruby/truffleruby/core/posix_functions.rb'
 c_file = 'src/main/c/truffleposix/posix_errno_wrappers.c.inc'
 
 C_NATIVE_GUARDS = {
-  'crypt' => 'HAVE_CRYPT',
   'dup3' => 'HAVE_DUP3',
   'posix_fadvise' => 'HAVE_POSIX_FADVISE',
   'setresgid' => 'HAVE_SETRESGID',


### PR DESCRIPTION
Linking libcrypt causes problems because it's not  SONAME-compatible between Linux-es:  Ubuntu 26.04 has libcrypt.so.1.1.0 and Fedora 43 has libcrypt.so.2.0.0.
So we load it dynamically with `dlopen()+dlsym()` and cache it.
Fixes [truffleruby-dev-builder](https://github.com/ruby/truffleruby-dev-builder/actions/runs/32815390000/job/97702557537) and [the release workflow](https://github.com/truffleruby/truffleruby/actions/runs/32811688589/job/97698542621).

Release workflow run on this branch: https://github.com/truffleruby/truffleruby/actions/runs/32889308301

I also tried to dynamically load from Java but that's way more messy:
`8 files changed, 131 insertions(+), 34 deletions(-)`
vs
`4 files changed, 40 insertions(+), 10 deletions(-)` (last commit)

Embedding [CRuby's fallback crypt()](https://github.com/ruby/ruby/blob/abc5a924d955b6babe353b55936d10c233ceed6e/missing/crypt.c) doesn't seem good as it declares a public `crypt()` and more functions, which would conflict if libcrypt is loaded later via FFI.