### PR TITLE
Update to GraalVM 25.3.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 New features:
 
 * Updated to Ruby 4.0.2 (#4231, @eregon).
-* Updated to GraalVM 25.2.4 (#4363, @eregon).
+* Updated to GraalVM 25.3.4.1 (#4363, @eregon).
 * Implemented `{Proc,Method,UnboundMethod,Thread::Backtrace::Location}#source_range` from Ruby 4.1 (@eregon).
 * Implemented `{Proc,Method,UnboundMethod,Thread::Backtrace::Location}#syntax_tree` from Ruby 4.1 (@eregon).
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ The minimum Java version for embedding TruffleRuby corresponds to the major of t
 
 | TruffleRuby version | Truffle version | GraalVM versions |
 | --- | --- | --- |
-| 40.0.0 | 25.2.4 | 25.2.x |
+| 40.0.0 | 25.3.4.1 | 25.3.x |
 | 34.0.0 | 25.0.2 | 21.0.x, 25.0.x |
 | 33.0.0 | 25.0.1 | 21.0.x, 25.0.x |
 | 25.0.0 | 25.0.0 | 21.0.x, 25.0.x |

--- a/mx.truffleruby/suite.py
+++ b/mx.truffleruby/suite.py
@@ -21,7 +21,7 @@ suite = {
             {
                 "name": "regex",
                 "subdir": True,
-                "version": "197eb76bf0e8af210db708288dfa4179fb4eddba",
+                "version": "521a3ee1817c7495de25f2f57506029c90068692",
                 "urls": [
                     {"url": "https://github.com/truffleruby/graal.git", "kind": "git"},
                     {"url": "https://curio.ssw.jku.at/nexus/content/repositories/snapshots", "kind": "binary"},
@@ -30,7 +30,7 @@ suite = {
             {
                 "name": "sulong",
                 "subdir": True,
-                "version": "197eb76bf0e8af210db708288dfa4179fb4eddba",
+                "version": "521a3ee1817c7495de25f2f57506029c90068692",
                 "urls": [
                     {"url": "https://github.com/truffleruby/graal.git", "kind": "git"},
                     {"url": "https://curio.ssw.jku.at/nexus/content/repositories/snapshots", "kind": "binary"},

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -88,7 +88,7 @@ LTS_JDK_VERSION = '21'
 IGV_JDK_VERSION = '21'
 DEFAULT_JDK_VERSION = 'latest'
 
-BOOTSTRAP_GRAALVM_VERSION = '25.2.4'
+BOOTSTRAP_GRAALVM_VERSION = '25.3.4.1'
 BOOTSTRAP_GRAALVM_EA_BUILD_TAG = nil
 
 # Not yet 'jdk.graal' as we test against 21 and 21 does not know 'jdk.graal'
@@ -2410,9 +2410,9 @@ module Commands
       dir = "#{JDKS_CACHE_DIR}/graalvm-#{tag}"
     else
       version = BOOTSTRAP_GRAALVM_VERSION
-      major, minor, patch = /^(\d+)\.(\d+)\.(\d+)$/.match(version).captures
+      major, minor, patches = /^(\d+)\.(\d+)\.(\d+(?:\.\d+)?)$/.match(version).captures
       archive_version = "#{major}i#{minor}"
-      jdk_version = "#{major}.0.#{patch}"
+      jdk_version = "#{major}.0.#{patches}"
       if ee?
         url = "https://gds.oracle.com/download/graal/#{archive_version}/archive/graalvm-jdk-#{archive_version}-#{jdk_version}_#{os}-#{arch}_bin.tar.gz"
         dir = "#{JDKS_CACHE_DIR}/graalvm-#{version}"


### PR DESCRIPTION
https://www.graalvm.org/release-notes/25.3/

The 4th digit is because Oracle moved to monthly security releases.

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.