### PR TITLE
Fix String#{tr!,tr_s!} to handle single character ranges properly

### DIFF
--- a/spec/tags/core/string/tr_s_tags.txt
+++ b/spec/tags/core/string/tr_s_tags.txt
@@ -1,1 +1,0 @@
-fails:String#tr_s accepts c1-c1 notation to denote range of one character

--- a/spec/tags/core/string/tr_tags.txt
+++ b/spec/tags/core/string/tr_tags.txt
@@ -1,1 +1,0 @@
-fails:String#tr accepts c1-c1 notation to denote range of one character

--- a/src/main/java/org/truffleruby/core/string/StringSupport.java
+++ b/src/main/java/org/truffleruby/core/string/StringSupport.java
@@ -636,8 +636,11 @@ public final class StringSupport {
                             context,
                             context.getCoreExceptions().argumentError("invalid range in string transliteration", node));
                 }
-                tr.gen = true;
-                tr.max = c;
+                // Do not expand single-character ranges (e.g. c1-c1)
+                if (tr.now < c) {
+                    tr.gen = true;
+                    tr.max = c;
+                }
             }
         }
         return tr.now;


### PR DESCRIPTION
Fix handling of single character range selectors (e.g. `a-a`) for String methods like `tr`, `tr_s`, `strip` etc.

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
