### PR TITLE
Refactor handling of character selector parameters in String strip-like methods

### DIFF
--- a/src/main/java/org/truffleruby/core/string/StringHelperNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringHelperNodes.java
@@ -201,14 +201,15 @@ public abstract class StringHelperNodes {
                 @Bind("libString.getTString($node, string)") AbstractTruffleString tstring,
                 @Bind("libString.getEncoding($node, string)") RubyEncoding encoding,
                 @Cached("libString.getEncoding($node, string)") RubyEncoding cachedEncoding,
-                @Cached(value = "squeeze()", dimensions = 1) boolean[] squeeze,
+                @Cached(value = "asciiFilter()", dimensions = 1) boolean[] asciiFilter,
                 @Cached("findEncoding($node, libString.getTString($node, string), libString.getEncoding($node, string), cachedArgs, checkEncodingNode)") RubyEncoding compatEncoding,
-                @Cached("makeTables($node, cachedArgs, squeeze, compatEncoding)") StringSupport.TrTables tables,
+                @Cached("makeNonAsciiFilter($node, cachedArgs, asciiFilter, compatEncoding)") StringSupport.NonAsciiFilter nonAsciiFilter,
                 @Cached @Shared TruffleString.GetInternalByteArrayNode byteArrayNode,
                 @Cached @Shared TruffleString.GetByteCodeRangeNode getByteCodeRangeNode) {
             var byteArray = byteArrayNode.execute(tstring, encoding.tencoding);
             var codeRange = getByteCodeRangeNode.execute(tstring, encoding.tencoding);
-            return StringSupport.strCount(byteArray, codeRange, squeeze, tables, compatEncoding.jcoding, this);
+            return StringSupport.strCount(byteArray, codeRange, asciiFilter, nonAsciiFilter, compatEncoding.jcoding,
+                    this);
         }
 
         @Specialization(guards = "!libString.getTString(this, string).isEmpty()")
@@ -235,9 +236,9 @@ public abstract class StringHelperNodes {
         @TruffleBoundary
         private int countSlow(InternalByteArray byteArray, TruffleString.CodeRange codeRange,
                 TStringWithEncoding[] tstringsWithEncs, RubyEncoding enc) {
-            final boolean[] table = squeeze();
-            final StringSupport.TrTables tables = makeTables(this, tstringsWithEncs, table, enc);
-            return StringSupport.strCount(byteArray, codeRange, table, tables, enc.jcoding, this);
+            boolean[] asciiFilter = asciiFilter();
+            StringSupport.NonAsciiFilter nonAsciiFilter = makeNonAsciiFilter(this, tstringsWithEncs, asciiFilter, enc);
+            return StringSupport.strCount(byteArray, codeRange, asciiFilter, nonAsciiFilter, enc.jcoding, this);
         }
     }
 
@@ -246,7 +247,7 @@ public abstract class StringHelperNodes {
         static final EncodingNodes.CheckStringEncodingNode UNCACHED_CHECK_ENCODING_NODE = EncodingNodesFactory.CheckStringEncodingNodeGen
                 .getUncached();
 
-        protected boolean[] squeeze() {
+        protected boolean[] asciiFilter() {
             return new boolean[StringSupport.TRANS_SIZE + 1];
         }
 
@@ -262,28 +263,29 @@ public abstract class StringHelperNodes {
             return enc;
         }
 
-        protected static StringSupport.TrTables makeTables(Node node, TStringWithEncoding[] tstringsWithEncs,
-                boolean[] squeeze, RubyEncoding enc) {
-            // The trSetupTable method will consume the bytes from the rope one encoded character at a time and
-            // build a TrTable from this. Previously we started with the encoding of rope zero, and at each
-            // stage found a compatible encoding to build that TrTable with. Although we now calculate a single
-            // encoding with which to build the tables it must be compatible with all ropes, so will not
-            // affect the consumption of characters from those ropes.
-            StringSupport.TrTables tables = StringSupport.trSetupTable(
+        protected static StringSupport.NonAsciiFilter makeNonAsciiFilter(Node node,
+                TStringWithEncoding[] tstringsWithEncs, boolean[] asciiFilter, RubyEncoding enc) {
+            // The trSetupFilter method will consume the bytes from the string one encoded character at a time and
+            // build a NonAsciiFilter from this. Previously we started with the encoding of the 1st string, and at each
+            // stage found a compatible encoding to build that NonAsciiFilter with. Although we now calculate a single
+            // encoding with which to build the filter it must be compatible with all strings, so will not
+            // affect the consumption of characters from those strings.
+            StringSupport.NonAsciiFilter nonAsciiFilter = StringSupport.trSetupFilter(
                     tstringsWithEncs[0].tstring,
                     tstringsWithEncs[0].encoding,
-                    squeeze,
+                    asciiFilter,
                     null,
                     true,
                     enc.jcoding,
                     node);
 
             for (int i = 1; i < tstringsWithEncs.length; i++) {
-                tables = StringSupport
-                        .trSetupTable(tstringsWithEncs[i].tstring, tstringsWithEncs[i].encoding, squeeze, tables, false,
-                                enc.jcoding, node);
+                var tstring = tstringsWithEncs[i].tstring;
+                var encoding = tstringsWithEncs[i].encoding;
+                nonAsciiFilter = StringSupport.trSetupFilter(tstring, encoding, asciiFilter, nonAsciiFilter, false,
+                        enc.jcoding, node);
             }
-            return tables;
+            return nonAsciiFilter;
         }
 
         @ExplodeLoop
@@ -328,11 +330,11 @@ public abstract class StringHelperNodes {
                 @Cached(inline = false) TruffleString.EqualNode equalNode,
                 @Cached @Exclusive RubyStringLibrary libString,
                 @Cached("libString.getEncoding($node, string)") RubyEncoding cachedEncoding,
-                @Cached(value = "squeeze()", dimensions = 1) boolean[] squeeze,
+                @Cached(value = "asciiFilter()", dimensions = 1) boolean[] asciiFilter,
                 @Cached("findEncoding(node, libString.getTString($node, string), libString.getEncoding($node, string), cachedArgs, UNCACHED_CHECK_ENCODING_NODE)") RubyEncoding compatEncoding,
-                @Cached("makeTables(node, cachedArgs, squeeze, compatEncoding)") StringSupport.TrTables tables,
+                @Cached("makeNonAsciiFilter(node, cachedArgs, asciiFilter, compatEncoding)") StringSupport.NonAsciiFilter nonAsciiFilter,
                 @Cached @Exclusive InlinedBranchProfile nullProfile) {
-            var processedTString = processStr(node, string, squeeze, compatEncoding, tables);
+            var processedTString = processStr(node, string, asciiFilter, compatEncoding, nonAsciiFilter);
             if (processedTString == null) {
                 nullProfile.enter(node);
                 return nil;
@@ -361,11 +363,12 @@ public abstract class StringHelperNodes {
         @TruffleBoundary
         private static Object deleteBangSlow(Node node, RubyString string, TStringWithEncoding[] tstringsWithEncs,
                 RubyEncoding enc) {
-            final boolean[] squeeze = new boolean[StringSupport.TRANS_SIZE + 1];
+            final boolean[] asciiFilter = new boolean[StringSupport.TRANS_SIZE + 1];
 
-            final StringSupport.TrTables tables = makeTables(node, tstringsWithEncs, squeeze, enc);
+            final StringSupport.NonAsciiFilter nonAsciiFilter = makeNonAsciiFilter(node, tstringsWithEncs, asciiFilter,
+                    enc);
 
-            var processedTString = processStr(node, string, squeeze, enc, tables);
+            var processedTString = processStr(node, string, asciiFilter, enc, nonAsciiFilter);
             if (processedTString == null) {
                 return nil;
             }
@@ -377,10 +380,11 @@ public abstract class StringHelperNodes {
         }
 
         @TruffleBoundary
-        private static TruffleString processStr(Node node, RubyString string, boolean[] squeeze, RubyEncoding enc,
-                StringSupport.TrTables tables) {
+        private static TruffleString processStr(Node node, RubyString string, boolean[] asciiFilter, RubyEncoding enc,
+                StringSupport.NonAsciiFilter nonAsciiFilter) {
             return StringSupport.delete_bangCommon19(
-                    new ATStringWithEncoding(string.tstring, string.getEncodingUncached()), squeeze, tables, enc, node);
+                    new ATStringWithEncoding(string.tstring, string.getEncodingUncached()), asciiFilter, nonAsciiFilter,
+                    enc, node);
         }
     }
 

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -1341,17 +1341,19 @@ public abstract class StringNodes {
             var tstring = string.tstring;
             var encoding = libString.getEncoding(node, string);
 
-            var squeeze = new boolean[StringSupport.TRANS_SIZE + 1];
-            StringSupport.TrTables tables = setupTables(node, args, tstring, encoding, squeeze, libString,
+            var asciiFilter = new boolean[StringSupport.TRANS_SIZE + 1];
+            StringSupport.NonAsciiFilter nonAsciiFilter = setupFilters(node, args, tstring, encoding, asciiFilter,
+                    libString,
                     toStrNode, checkEncodingNode);
 
             int startIndex;
             if (singleByteProfile.profile(node,
                     StringGuards.isSingleByteOptimizable(node, tstring, encoding, singleByteOptimizableNode))) {
                 var byteArray = byteArrayNode.execute(tstring, encoding.tencoding);
-                startIndex = StringSupport.singleByteLstripStartIndex(byteArray, squeeze);
+                startIndex = StringSupport.singleByteLstripStartIndex(byteArray, asciiFilter);
             } else {
-                startIndex = StringSupport.multiByteLstripStartIndex(tstring, encoding, squeeze, tables, node);
+                startIndex = StringSupport.multiByteLstripStartIndex(tstring, encoding, asciiFilter, nonAsciiFilter,
+                        node);
             }
 
             return trimLeading(node, string, tstring, encoding.tencoding, startIndex, substringNode,
@@ -1470,17 +1472,17 @@ public abstract class StringNodes {
             var tstring = string.tstring;
             var encoding = libString.getEncoding(node, string);
 
-            var squeeze = new boolean[StringSupport.TRANS_SIZE + 1];
-            StringSupport.TrTables tables = setupTables(node, args, tstring, encoding, squeeze, libString,
-                    toStrNode, checkEncodingNode);
+            var asciiFilter = new boolean[StringSupport.TRANS_SIZE + 1];
+            StringSupport.NonAsciiFilter nonAsciiFilter = setupFilters(node, args, tstring, encoding, asciiFilter,
+                    libString, toStrNode, checkEncodingNode);
 
             int endIndex;
             if (singleByteProfile.profile(node,
                     StringGuards.isSingleByteOptimizable(node, tstring, encoding, singleByteOptimizableNode))) {
                 var byteArray = byteArrayNode.execute(tstring, encoding.tencoding);
-                endIndex = StringSupport.singleByteRstripEndIndex(byteArray, squeeze);
+                endIndex = StringSupport.singleByteRstripEndIndex(byteArray, asciiFilter);
             } else {
-                endIndex = StringSupport.multiByteRstripEndIndex(tstring, encoding, squeeze, tables, node);
+                endIndex = StringSupport.multiByteRstripEndIndex(tstring, encoding, asciiFilter, nonAsciiFilter, node);
             }
 
             return trimTrailing(node, string, tstring, encoding.tencoding, endIndex, substringNode,
@@ -1502,20 +1504,20 @@ public abstract class StringNodes {
 
     }
 
-    // Builds the character lookup tables and squeeze flags for selector arguments after validating encoding compatibility.
-    private static StringSupport.TrTables setupTables(Node node, Object[] args,
-            AbstractTruffleString tstring, RubyEncoding encoding, boolean[] squeeze,
+    // Build filters for ascii and non-ascii characters for given character selectors
+    private static StringSupport.NonAsciiFilter setupFilters(Node node, Object[] args,
+            AbstractTruffleString tstring, RubyEncoding encoding, boolean[] asciiFilter,
             RubyStringLibrary libString, ToStrNode toStrNode, CheckStringEncodingNode checkEncodingNode) {
-        StringSupport.TrTables tables = null;
+        StringSupport.NonAsciiFilter nonAsciiFilter = null;
         for (int i = 0; i < args.length; i++) {
             Object arg = toStrNode.execute(node, args[i]);
             var argTString = libString.getTString(node, arg);
             var argEncoding = libString.getEncoding(node, arg);
             var negotiatedEncoding = checkEncodingNode.execute(node, tstring, encoding, argTString, argEncoding);
-            tables = StringSupport.trSetupTable(argTString, argEncoding, squeeze, tables, i == 0,
+            nonAsciiFilter = StringSupport.trSetupFilter(argTString, argEncoding, asciiFilter, nonAsciiFilter, i == 0,
                     negotiatedEncoding.jcoding, node);
         }
-        return tables;
+        return nonAsciiFilter;
     }
 
     @CoreMethod(names = "dump")
@@ -1790,14 +1792,14 @@ public abstract class StringNodes {
 
             final TStringBuilder buffer = TStringBuilder.create(string);
 
-            final boolean[] squeeze = new boolean[StringSupport.TRANS_SIZE];
+            final boolean[] asciiFilter = new boolean[StringSupport.TRANS_SIZE];
             for (int i = 0; i < StringSupport.TRANS_SIZE; i++) {
-                squeeze[i] = true;
+                asciiFilter[i] = true;
             }
 
             if (StringGuards.isSingleByteOptimizable(this, string.tstring, string.getEncodingUncached(),
                     singleByteOptimizableNode)) {
-                if (!StringSupport.singleByteSqueeze(buffer, squeeze)) {
+                if (!StringSupport.singleByteSqueeze(buffer, asciiFilter)) {
                     return nil;
                 } else {
                     string.setTString(buffer.toTString(), buffer.getRubyEncoding());
@@ -1805,7 +1807,7 @@ public abstract class StringNodes {
             } else {
                 var codeRange = string.tstring
                         .getByteCodeRangeUncached(RubyStringLibrary.getUncached().getTEncoding(this, string));
-                if (!StringSupport.multiByteSqueeze(buffer, codeRange, squeeze, null,
+                if (!StringSupport.multiByteSqueeze(buffer, codeRange, asciiFilter, null,
                         string.getEncodingUncached().jcoding, false, this)) {
                     return nil;
                 } else {
@@ -1843,14 +1845,14 @@ public abstract class StringNodes {
             var otherEncoding = RubyStringLibrary.getUncached().getEncoding(node, otherStr);
             RubyEncoding enc = checkEncodingNode.execute(node, string.tstring, string.getEncodingUncached(),
                     otherTString, otherEncoding);
-            final boolean squeeze[] = new boolean[StringSupport.TRANS_SIZE + 1];
+            final boolean[] asciiFilter = new boolean[StringSupport.TRANS_SIZE + 1];
 
             boolean singlebyte = TStringUtils.isSingleByteOptimizable(string.tstring, string.getEncodingUncached()) &&
                     TStringUtils.isSingleByteOptimizable(otherTString, otherEncoding);
 
             if (singlebyte && otherTString.byteLength(otherEncoding.tencoding) == 1 && otherStrings.length == 1) {
-                squeeze[otherTString.readByteUncached(0, otherEncoding.tencoding)] = true;
-                if (!StringSupport.singleByteSqueeze(buffer, squeeze)) {
+                asciiFilter[otherTString.readByteUncached(0, otherEncoding.tencoding)] = true;
+                if (!StringSupport.singleByteSqueeze(buffer, asciiFilter)) {
                     return nil;
                 } else {
                     string.setTString(buffer.toTString(), buffer.getRubyEncoding());
@@ -1858,8 +1860,8 @@ public abstract class StringNodes {
                 }
             }
 
-            StringSupport.TrTables tables = StringSupport
-                    .trSetupTable(otherTString, otherEncoding, squeeze, null, true, enc.jcoding, node);
+            StringSupport.NonAsciiFilter nonAsciiFilter = StringSupport
+                    .trSetupFilter(otherTString, otherEncoding, asciiFilter, null, true, enc.jcoding, node);
 
             for (int i = 1; i < otherStrings.length; i++) {
                 otherStr = otherStrings[i];
@@ -1868,12 +1870,12 @@ public abstract class StringNodes {
                 enc = checkEncodingNode.execute(node, string.tstring, string.getEncodingUncached(), otherTString,
                         otherEncoding);
                 singlebyte = singlebyte && TStringUtils.isSingleByteOptimizable(otherTString, otherEncoding);
-                tables = StringSupport.trSetupTable(otherTString, otherEncoding, squeeze, tables, false, enc.jcoding,
-                        node);
+                nonAsciiFilter = StringSupport.trSetupFilter(otherTString, otherEncoding, asciiFilter, nonAsciiFilter,
+                        false, enc.jcoding, node);
             }
 
             if (singlebyte) {
-                if (!StringSupport.singleByteSqueeze(buffer, squeeze)) {
+                if (!StringSupport.singleByteSqueeze(buffer, asciiFilter)) {
                     return nil;
                 } else {
                     string.setTString(buffer.toTString(), buffer.getRubyEncoding());
@@ -1881,7 +1883,8 @@ public abstract class StringNodes {
             } else {
                 var codeRange = string.tstring
                         .getByteCodeRangeUncached(RubyStringLibrary.getUncached().getTEncoding(node, string));
-                if (!StringSupport.multiByteSqueeze(buffer, codeRange, squeeze, tables, enc.jcoding, true, node)) {
+                if (!StringSupport.multiByteSqueeze(buffer, codeRange, asciiFilter, nonAsciiFilter, enc.jcoding, true,
+                        node)) {
                     return nil;
                 } else {
                     string.setTString(buffer.toTString(), buffer.getRubyEncoding());

--- a/src/main/java/org/truffleruby/core/string/StringNodes.java
+++ b/src/main/java/org/truffleruby/core/string/StringNodes.java
@@ -1310,7 +1310,6 @@ public abstract class StringNodes {
                 @Cached @Shared TruffleString.SubstringByteIndexNode substringNode,
                 @Cached @Exclusive InlinedConditionProfile singleByteProfile,
                 @Cached @Exclusive InlinedConditionProfile noopProfile,
-                @Cached @Exclusive InlinedConditionProfile emptyStringProfile,
                 @Bind Node node) {
             var tstring = string.tstring;
             var encoding = libString.getEncoding(node, string);
@@ -1325,7 +1324,7 @@ public abstract class StringNodes {
             }
 
             return trimLeading(node, string, tstring, encoding.tencoding, startIndex, substringNode,
-                    noopProfile, emptyStringProfile);
+                    noopProfile);
         }
 
         @Specialization(guards = { "!string.tstring.isEmpty()", "!noArguments(args)" })
@@ -1338,7 +1337,6 @@ public abstract class StringNodes {
                 @Cached @Exclusive CheckStringEncodingNode checkEncodingNode,
                 @Cached @Exclusive InlinedConditionProfile singleByteProfile,
                 @Cached @Exclusive InlinedConditionProfile noopProfile,
-                @Cached @Exclusive InlinedConditionProfile emptyStringProfile,
                 @Bind Node node) {
             var tstring = string.tstring;
             var encoding = libString.getEncoding(node, string);
@@ -1357,26 +1355,21 @@ public abstract class StringNodes {
             }
 
             return trimLeading(node, string, tstring, encoding.tencoding, startIndex, substringNode,
-                    noopProfile, emptyStringProfile);
+                    noopProfile);
         }
 
         // Trims leading characters from the string up to startIndex.
         private static Object trimLeading(Node node, RubyString string, AbstractTruffleString tstring,
                 TruffleString.Encoding tencoding, int startIndex,
                 TruffleString.SubstringByteIndexNode substringNode,
-                InlinedConditionProfile noopProfile,
-                InlinedConditionProfile emptyStringProfile) {
+                InlinedConditionProfile noopProfile) {
             if (noopProfile.profile(node, startIndex == -1)) {
                 return nil;
             }
 
             int totalLength = tstring.byteLength(tencoding);
-            if (emptyStringProfile.profile(node, startIndex == totalLength)) {
-                string.setTString(tencoding.getEmpty());
-            } else {
-                int substringByteLength = totalLength - startIndex;
-                string.setTString(substringNode.execute(tstring, startIndex, substringByteLength, tencoding, true));
-            }
+            int substringByteLength = totalLength - startIndex;
+            string.setTString(substringNode.execute(tstring, startIndex, substringByteLength, tencoding, true));
             return string;
         }
 
@@ -1446,7 +1439,6 @@ public abstract class StringNodes {
                 @Cached @Shared TruffleString.SubstringByteIndexNode substringNode,
                 @Cached @Exclusive InlinedConditionProfile singleByteProfile,
                 @Cached @Exclusive InlinedConditionProfile noopProfile,
-                @Cached @Exclusive InlinedConditionProfile emptyStringProfile,
                 @Bind Node node) {
             var tstring = string.tstring;
             var encoding = libString.getEncoding(node, string);
@@ -1461,7 +1453,7 @@ public abstract class StringNodes {
             }
 
             return trimTrailing(node, string, tstring, encoding.tencoding, endIndex, substringNode,
-                    noopProfile, emptyStringProfile);
+                    noopProfile);
         }
 
         @Specialization(guards = { "!string.tstring.isEmpty()", "!noArguments(args)" })
@@ -1474,7 +1466,6 @@ public abstract class StringNodes {
                 @Cached @Exclusive CheckStringEncodingNode checkEncodingNode,
                 @Cached @Exclusive InlinedConditionProfile singleByteProfile,
                 @Cached @Exclusive InlinedConditionProfile noopProfile,
-                @Cached @Exclusive InlinedConditionProfile emptyStringProfile,
                 @Bind Node node) {
             var tstring = string.tstring;
             var encoding = libString.getEncoding(node, string);
@@ -1493,24 +1484,19 @@ public abstract class StringNodes {
             }
 
             return trimTrailing(node, string, tstring, encoding.tencoding, endIndex, substringNode,
-                    noopProfile, emptyStringProfile);
+                    noopProfile);
         }
 
         // Trims trailing characters from the string up to endIndex.
         private static Object trimTrailing(Node node, RubyString string, AbstractTruffleString tstring,
                 TruffleString.Encoding tencoding, int endIndex,
                 TruffleString.SubstringByteIndexNode substringNode,
-                InlinedConditionProfile noopProfile,
-                InlinedConditionProfile emptyStringProfile) {
+                InlinedConditionProfile noopProfile) {
             if (noopProfile.profile(node, endIndex == -1)) {
                 return nil;
             }
 
-            if (emptyStringProfile.profile(node, endIndex == 0)) {
-                string.setTString(tencoding.getEmpty());
-            } else {
-                string.setTString(substringNode.execute(tstring, 0, endIndex, tencoding, true));
-            }
+            string.setTString(substringNode.execute(tstring, 0, endIndex, tencoding, true));
             return string;
         }
 

--- a/src/main/java/org/truffleruby/core/string/StringSupport.java
+++ b/src/main/java/org/truffleruby/core/string/StringSupport.java
@@ -360,8 +360,8 @@ public final class StringSupport {
 
     /** rb_str_count */
     @TruffleBoundary
-    public static int strCount(InternalByteArray byteArray, TruffleString.CodeRange codeRange, boolean[] table,
-            TrTables tables, Encoding enc, Node node) {
+    public static int strCount(InternalByteArray byteArray, TruffleString.CodeRange codeRange, boolean[] asciiFilter,
+            NonAsciiFilter nonAsciiFilter, Encoding enc, Node node) {
         final byte[] bytes = byteArray.getArray();
         int p = byteArray.getOffset();
         final int end = byteArray.getEnd();
@@ -371,14 +371,14 @@ public final class StringSupport {
         while (p < end) {
             int c;
             if (asciiCompat && (c = bytes[p] & 0xff) < 0x80) {
-                if (table[c]) {
+                if (asciiFilter[c]) {
                     count++;
                 }
                 p++;
             } else {
                 c = codePoint(enc, codeRange, bytes, p, end, node);
                 int cl = codeLength(enc, c);
-                if (trFind(c, table, tables)) {
+                if (trFind(c, asciiFilter, nonAsciiFilter)) {
                     count++;
                 }
                 p += cl;
@@ -472,15 +472,15 @@ public final class StringSupport {
     }
 
     /** tr_setup_table */
-    public static final class TrTables {
+    public static final class NonAsciiFilter {
         IntHashMap<Object> del, noDel; // used as ~ Set
     }
 
     private static final Object DUMMY_VALUE = "";
 
     @TruffleBoundary
-    public static TrTables trSetupTable(AbstractTruffleString str, RubyEncoding encoding, boolean[] stable,
-            TrTables tables, boolean first, Encoding enc, Node node) {
+    public static NonAsciiFilter trSetupFilter(AbstractTruffleString str, RubyEncoding encoding, boolean[] asciiFilter,
+            NonAsciiFilter nonAsciiFilter, boolean first, Encoding enc, Node node) {
         int i, l[] = { 0 };
         final boolean cflag;
 
@@ -497,15 +497,15 @@ public final class StringSupport {
 
         if (first) {
             for (i = 0; i < TRANS_SIZE; i++) {
-                stable[i] = true;
+                asciiFilter[i] = true;
             }
-            stable[TRANS_SIZE] = cflag;
-        } else if (stable[TRANS_SIZE] && !cflag) {
-            stable[TRANS_SIZE] = false;
+            asciiFilter[TRANS_SIZE] = cflag;
+        } else if (asciiFilter[TRANS_SIZE] && !cflag) {
+            asciiFilter[TRANS_SIZE] = false;
         }
 
-        if (tables == null) {
-            tables = new TrTables();
+        if (nonAsciiFilter == null) {
+            nonAsciiFilter = new NonAsciiFilter();
         }
 
         byte[] buf = null; // lazy initialized
@@ -523,15 +523,15 @@ public final class StringSupport {
                 // update the buff at [c] :
                 buf[c & 0xff] = (byte) (cflag ? 0 : 1);
             } else {
-                if (table == null && (first || tables.del != null || stable[TRANS_SIZE])) {
+                if (table == null && (first || nonAsciiFilter.del != null || asciiFilter[TRANS_SIZE])) {
                     if (cflag) {
-                        ptable = tables.noDel;
+                        ptable = nonAsciiFilter.noDel;
                         table = ptable != null ? ptable : new IntHashMap<>(8);
-                        tables.noDel = table;
+                        nonAsciiFilter.noDel = table;
                     } else {
                         table = new IntHashMap<>(8);
-                        ptable = tables.del;
-                        tables.del = table;
+                        ptable = nonAsciiFilter.del;
+                        nonAsciiFilter.del = table;
                     }
                 }
 
@@ -552,27 +552,31 @@ public final class StringSupport {
         }
         if (buf != null) {
             for (i = 0; i < TRANS_SIZE; i++) {
-                stable[i] = stable[i] && buf[i] != 0;
+                asciiFilter[i] = asciiFilter[i] && buf[i] != 0;
             }
         } else {
             for (i = 0; i < TRANS_SIZE; i++) {
-                stable[i] = stable[i] && cflag;
+                asciiFilter[i] = asciiFilter[i] && cflag;
             }
         }
 
         if (table == null && !cflag) {
-            tables.del = null;
+            nonAsciiFilter.del = null;
         }
 
-        return tables;
+        return nonAsciiFilter;
     }
 
-    public static boolean trFind(final int c, final boolean[] table, final TrTables tables) {
+    public static boolean trFind(final int c, final boolean[] asciiFilter, final NonAsciiFilter nonAsciiFilter) {
         if (c < TRANS_SIZE) {
-            return table[c];
+            return asciiFilter[c];
         }
 
-        final IntHashMap<Object> del = tables.del, noDel = tables.noDel;
+        if (nonAsciiFilter == null) {
+            return asciiFilter[TRANS_SIZE];
+        }
+
+        final IntHashMap<Object> del = nonAsciiFilter.del, noDel = nonAsciiFilter.noDel;
 
         if (del != null) {
             if (del.get(c) != null &&
@@ -583,7 +587,7 @@ public final class StringSupport {
             return false;
         }
 
-        return table[TRANS_SIZE];
+        return asciiFilter[TRANS_SIZE];
     }
 
     @TruffleBoundary
@@ -919,7 +923,8 @@ public final class StringSupport {
 
     /** rb_str_delete_bang */
     @TruffleBoundary
-    public static TruffleString delete_bangCommon19(ATStringWithEncoding rubyString, boolean[] squeeze, TrTables tables,
+    public static TruffleString delete_bangCommon19(ATStringWithEncoding rubyString, boolean[] asciiFilter,
+            NonAsciiFilter nonAsciiFilter,
             RubyEncoding encoding, Node node) {
         Encoding enc = encoding.jcoding;
         int s = 0;
@@ -932,7 +937,7 @@ public final class StringSupport {
         while (s < send) {
             int c;
             if (asciiCompatible && Encoding.isAscii(c = bytes[s] & 0xff)) {
-                if (squeeze[c]) {
+                if (asciiFilter[c]) {
                     modified = true;
                 } else {
                     if (t != s) {
@@ -944,7 +949,7 @@ public final class StringSupport {
             } else {
                 c = codePoint(enc, rubyString.getCodeRange(), bytes, s, send, node);
                 int cl = codeLength(enc, c);
-                if (trFind(c, squeeze, tables)) {
+                if (trFind(c, asciiFilter, nonAsciiFilter)) {
                     modified = true;
                 } else {
                     if (t != s) {
@@ -1278,7 +1283,7 @@ public final class StringSupport {
         return 0;
     }
 
-    public static boolean singleByteSqueeze(TStringBuilder value, boolean squeeze[]) {
+    public static boolean singleByteSqueeze(TStringBuilder value, boolean[] asciiFilter) {
         int s = 0;
         int t = s;
         int send = s + value.getLength();
@@ -1287,7 +1292,7 @@ public final class StringSupport {
 
         while (s < send) {
             int c = bytes[s++] & 0xff;
-            if (c != save || !squeeze[c]) {
+            if (c != save || !asciiFilter[c]) {
                 bytes[t++] = (byte) (save = c);
             }
         }
@@ -1302,7 +1307,7 @@ public final class StringSupport {
 
     @TruffleBoundary
     public static boolean multiByteSqueeze(TStringBuilder value, TruffleString.CodeRange originalCodeRange,
-            boolean[] squeeze, TrTables tables, Encoding enc, boolean isArg, Node node) {
+            boolean[] asciiFilter, NonAsciiFilter nonAsciiFilter, Encoding enc, boolean isArg, Node node) {
         int s = 0;
         int t = s;
         int send = s + value.getLength();
@@ -1312,14 +1317,14 @@ public final class StringSupport {
 
         while (s < send) {
             if (enc.isAsciiCompatible() && (c = bytes[s] & 0xff) < 0x80) {
-                if (c != save || (isArg && !squeeze[c])) {
+                if (c != save || (isArg && !asciiFilter[c])) {
                     bytes[t++] = (byte) (save = c);
                 }
                 s++;
             } else {
                 c = codePoint(enc, originalCodeRange, bytes, s, send, node);
                 int cl = codeLength(enc, c);
-                if (c != save || (isArg && !trFind(c, squeeze, tables))) {
+                if (c != save || (isArg && !trFind(c, asciiFilter, nonAsciiFilter))) {
                     if (t != s) {
                         enc.codeToMbc(c, bytes, t);
                     }
@@ -1338,21 +1343,21 @@ public final class StringSupport {
         return false;
     }
 
-    public static int singleByteRstripEndIndex(InternalByteArray byteArray, boolean[] squeeze) {
+    public static int singleByteRstripEndIndex(InternalByteArray byteArray, boolean[] asciiFilter) {
         final int len = byteArray.getLength();
         if (len == 0) {
             return -1;
         }
 
         final int lastByte = byteArray.get(len - 1) & 0xff;
-        if (squeeze != null ? !squeeze[lastByte] : !isAsciiSpaceOrNull(lastByte)) {
+        if (asciiFilter != null ? !asciiFilter[lastByte] : !isAsciiSpaceOrNull(lastByte)) {
             return -1;
         }
 
         int i = len - 2;
         while (i >= 0) {
             final int b = byteArray.get(i) & 0xff;
-            if (squeeze != null ? !squeeze[b] : !isAsciiSpaceOrNull(b)) {
+            if (asciiFilter != null ? !asciiFilter[b] : !isAsciiSpaceOrNull(b)) {
                 return i + 1;
             }
             i--;
@@ -1363,7 +1368,7 @@ public final class StringSupport {
 
     @TruffleBoundary
     public static int multiByteRstripEndIndex(AbstractTruffleString tstring, RubyEncoding encoding,
-            boolean[] squeeze, TrTables tables, Node node) {
+            boolean[] asciiFilter, NonAsciiFilter nonAsciiFilter, Node node) {
         final var tencoding = encoding.tencoding;
         var iterator = CreateBackwardCodePointIteratorNode.getUncached().execute(tstring, tencoding,
                 ErrorHandling.RETURN_NEGATIVE);
@@ -1374,7 +1379,9 @@ public final class StringSupport {
                     RubyContext.get(node).getCoreExceptions().argumentErrorInvalidByteSequence(encoding, node));
         }
 
-        boolean matches = squeeze != null ? trFind(codePoint, squeeze, tables) : isAsciiSpaceOrNull(codePoint);
+        boolean matches = asciiFilter != null
+                ? trFind(codePoint, asciiFilter, nonAsciiFilter)
+                : isAsciiSpaceOrNull(codePoint);
         if (!matches) {
             return -1;
         }
@@ -1388,7 +1395,9 @@ public final class StringSupport {
                         RubyContext.get(node).getCoreExceptions().argumentErrorInvalidByteSequence(encoding, node));
             }
 
-            matches = squeeze != null ? trFind(codePoint, squeeze, tables) : isAsciiSpaceOrNull(codePoint);
+            matches = asciiFilter != null
+                    ? trFind(codePoint, asciiFilter, nonAsciiFilter)
+                    : isAsciiSpaceOrNull(codePoint);
             if (!matches) {
                 return byteIndex;
             }
@@ -1397,21 +1406,21 @@ public final class StringSupport {
         return 0;
     }
 
-    public static int singleByteLstripStartIndex(InternalByteArray byteArray, boolean[] squeeze) {
+    public static int singleByteLstripStartIndex(InternalByteArray byteArray, boolean[] asciiFilter) {
         final int len = byteArray.getLength();
         if (len == 0) {
             return -1;
         }
 
         final int firstByte = byteArray.get(0) & 0xff;
-        if (squeeze != null ? !squeeze[firstByte] : !isAsciiSpaceOrNull(firstByte)) {
+        if (asciiFilter != null ? !asciiFilter[firstByte] : !isAsciiSpaceOrNull(firstByte)) {
             return -1;
         }
 
         int i = 1;
         while (i < len) {
             final int b = byteArray.get(i) & 0xff;
-            if (squeeze != null ? !squeeze[b] : !isAsciiSpaceOrNull(b)) {
+            if (asciiFilter != null ? !asciiFilter[b] : !isAsciiSpaceOrNull(b)) {
                 return i;
             }
             i++;
@@ -1422,7 +1431,7 @@ public final class StringSupport {
 
     @TruffleBoundary
     public static int multiByteLstripStartIndex(AbstractTruffleString tstring, RubyEncoding encoding,
-            boolean[] squeeze, TrTables tables, Node node) {
+            boolean[] asciiFilter, NonAsciiFilter nonAsciiFilter, Node node) {
         final var tencoding = encoding.tencoding;
         var iterator = CreateCodePointIteratorNode.getUncached().execute(tstring, tencoding,
                 ErrorHandling.RETURN_NEGATIVE);
@@ -1433,7 +1442,9 @@ public final class StringSupport {
                     RubyContext.get(node).getCoreExceptions().argumentErrorInvalidByteSequence(encoding, node));
         }
 
-        boolean matches = squeeze != null ? trFind(codePoint, squeeze, tables) : isAsciiSpaceOrNull(codePoint);
+        boolean matches = asciiFilter != null
+                ? trFind(codePoint, asciiFilter, nonAsciiFilter)
+                : isAsciiSpaceOrNull(codePoint);
         if (!matches) {
             return -1;
         }
@@ -1447,7 +1458,9 @@ public final class StringSupport {
                         RubyContext.get(node).getCoreExceptions().argumentErrorInvalidByteSequence(encoding, node));
             }
 
-            matches = squeeze != null ? trFind(codePoint, squeeze, tables) : isAsciiSpaceOrNull(codePoint);
+            matches = asciiFilter != null
+                    ? trFind(codePoint, asciiFilter, nonAsciiFilter)
+                    : isAsciiSpaceOrNull(codePoint);
             if (!matches) {
                 return byteIndex;
             }

--- a/src/main/java/org/truffleruby/core/string/StringSupport.java
+++ b/src/main/java/org/truffleruby/core/string/StringSupport.java
@@ -572,10 +572,6 @@ public final class StringSupport {
             return asciiFilter[c];
         }
 
-        if (nonAsciiFilter == null) {
-            return asciiFilter[TRANS_SIZE];
-        }
-
         final IntHashMap<Object> del = nonAsciiFilter.del, noDel = nonAsciiFilter.noDel;
 
         if (del != null) {


### PR DESCRIPTION
Follow-up for #4418.

Changes:
- removed excessive checks for 0 length of a result string
- renamed local variables `sqeeze`/`stable` and `tables` into `asciiFilter` and `nonAsciiFilter`, a `TrTables` class into `NonAsciiFilter`.

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
