### PR TITLE
Require CRuby 3.0+ for jt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ TruffleRuby uses the `mx` build tool (GraalVM ecosystem) but wraps it behind the
 
 ### Prerequisites
 
-- Ruby >= 2.3 (system Ruby, for running `jt`)
+- Ruby >= 3.0 (system Ruby, for running `jt`)
 - Python >= 3.8 (for `mx`)
 - A JVMCI-enabled JDK (if `JAVA_HOME` is set but doesn't have JVMCI, unset it so `jt` downloads a suitable JDK)
 - `make`, `gcc`/`g++`, `cmake`, `git`, `wget`

--- a/doc/contributor/workflow.md
+++ b/doc/contributor/workflow.md
@@ -12,7 +12,7 @@ by a package manager. Without it the build fails with `'stdio.h' file not found`
 
 Additionally, you will need:
 
-* Ruby >= 2.3 (we stick at this version as it is available all the way back to for example Ubuntu 16.04)
+* Ruby >= 3.0 for `jt`
 * Python >= 3.8 for `mx`
 * Perl >= 5.10 and the Perl core library, for building OpenSSL: `dnf install perl-core`/`apt-get install perl`
 * `git`

--- a/test/truffle/ecosystem/blog6/Gemfile
+++ b/test/truffle/ecosystem/blog6/Gemfile
@@ -1,8 +1,6 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '>= 2.3.1'
-
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 6.0'
 

--- a/tool/build-with-old-glibc/Dockerfile
+++ b/tool/build-with-old-glibc/Dockerfile
@@ -6,7 +6,8 @@ FROM almalinux:8
 RUN ldd --version
 
 # See workflow.md#requirements
-RUN dnf install -y git wget ruby python3.12 cmake perl-core maven make gcc gcc-c++ ca-certificates zlib-devel
+RUN dnf module install -y ruby:3.0
+RUN dnf install -y git wget python3.12 cmake perl-core maven make gcc gcc-c++ ca-certificates zlib-devel
 
 RUN useradd -ms /bin/bash test
 RUN mkdir -p /truffleruby-ws /release

--- a/tool/jt.rb
+++ b/tool/jt.rb
@@ -27,7 +27,7 @@ if RUBY_ENGINE != 'ruby' && !RUBY_DESCRIPTION.include?('Native')
   STDERR.puts '    alias jt=/path/to/truffleruby/bin/jt'
 end
 
-abort "ERROR: jt requires Ruby 2.3 and above, was #{RUBY_VERSION}" if (RUBY_VERSION.split('.').map(&:to_i) <=> [2, 3, 0]) < 0
+abort "ERROR: jt requires Ruby 3.0 and above, was #{RUBY_VERSION}" if RUBY_VERSION < '3'
 
 SYSTEM_RUBY = ENV['SYSTEM_RUBY'] || 'ruby'
 
@@ -165,8 +165,7 @@ module Utilities
   end
 
   def soext
-    # RbConfig::CONFIG["SOEXT"] is not set for system ruby 2.3 in macOS CI
-    RbConfig::CONFIG.fetch('SOEXT') { darwin? ? 'dylib' : 'so' }
+    RbConfig::CONFIG.fetch('SOEXT')
   end
 
   def bold(text)


### PR DESCRIPTION
To fix https://github.com/truffleruby/truffleruby/actions/runs/33592971906/job/100130586461
```
[31](https://github.com/truffleruby/truffleruby/actions/runs/33592971906/job/100130586461#step:5:1932)
18.79 + jt sforceimports
18.85 /truffleruby-ws/truffleruby/tool/jt.rb:3031: syntax error, unexpected ']'
18.85 ..._comment_body = text.lines[1..].map { |line| line == "\n" ? ...
18.85 ...                              ^
```