### PR TITLE
Add an exact long-arithmetic fast path for sprintf %f

### DIFF
--- a/src/main/java/org/truffleruby/core/format/format/FormatFFloatNode.java
+++ b/src/main/java/org/truffleruby/core/format/format/FormatFFloatNode.java
@@ -51,9 +51,168 @@ public abstract class FormatFFloatNode extends FormatFloatGenericNode {
         return formatNumber(width, precision, dval);
     }
 
+    /** 10^0 .. 10^18 */
+    private static final long[] POW10 = new long[19];
+    /** 5^0 .. 5^18 */
+    private static final long[] POW5 = new long[19];
+    static {
+        POW10[0] = 1;
+        POW5[0] = 1;
+        for (int i = 1; i < POW10.length; i++) {
+            POW10[i] = POW10[i - 1] * 10;
+            POW5[i] = POW5[i - 1] * 5;
+        }
+    }
+
     @TruffleBoundary
     @Override
     protected byte[] doFormat(int precision, Object value) {
+        if (value instanceof Double) {
+            final byte[] fast = fastFixedFormat(precision, (double) value);
+            if (fast != null) {
+                return fast;
+            }
+        }
+        return slowFormat(precision, value);
+    }
+
+    /** Formats {@code %.<precision>f} exactly like C printf (round half to even on the exact decimal value of the
+     * double), using only long arithmetic: value * 10^precision = mantissa * 5^precision * 2^(exponent + precision),
+     * computed exactly in 128 bits and rounded once. Returns null when out of range for this fast path (then the
+     * DecimalFormat path is used). This avoids DecimalFormat and its FloatingDecimal digit generation, which dominated
+     * profiles of ERB rendering with float formatting. */
+    private byte[] fastFixedFormat(int precision, double dval) {
+        if (precision < 0 || precision > 17) {
+            return null;
+        }
+
+        final long bits = Double.doubleToRawLongBits(dval);
+        final boolean negative = bits < 0;
+        final int biasedExponent = (int) ((bits >>> 52) & 0x7ff);
+
+        final long scaled; // round_half_even(|dval| * 10^precision)
+        if (biasedExponent == 0) {
+            if ((bits << 1) != 0) {
+                return null; // subnormal: rare, use the slow path
+            }
+            scaled = 0; // +0.0 or -0.0
+        } else {
+            assert biasedExponent != 0x7ff : "special values are handled by other specializations";
+            final long mantissa = (bits & 0x000f_ffff_ffff_ffffL) | (1L << 52);
+            final int exponent = biasedExponent - 1075; // |dval| = mantissa * 2^exponent
+            // |dval| * 10^precision = product * 2^shift, exactly (product = mantissa * 5^precision < 2^96)
+            final long productLow = mantissa * POW5[precision];
+            final long productHigh = Math.multiplyHigh(mantissa, POW5[precision]);
+            final int shift = exponent + precision;
+
+            if (shift >= 0) {
+                // An exact integer: give up if it does not fit in a positive long
+                if (productHigh != 0 || shift >= 63 || (productLow >>> (63 - shift)) != 0) {
+                    return null;
+                }
+                scaled = productLow << shift;
+            } else {
+                scaled = shiftRightHalfEven(productHigh, productLow, -shift);
+                if (scaled < 0) {
+                    return null; // did not fit in a positive long
+                }
+            }
+        }
+
+        return fixedDigits(precision, negative, scaled);
+    }
+
+    /** round_half_even((high:low) >> shift), or -1 if the result does not fit in a positive long */
+    private static long shiftRightHalfEven(long high, long low, int shift) {
+        final long result;
+        final boolean roundUp;
+        if (shift < 64) {
+            if ((shift == 0 ? high : high >>> shift) != 0) {
+                return -1;
+            }
+            result = shift == 0 ? low : ((high << (64 - shift)) | (low >>> shift));
+            if (result < 0) {
+                return -1;
+            }
+            if (shift == 0) {
+                return result;
+            }
+            final long remainder = low & ((1L << shift) - 1);
+            final long half = 1L << (shift - 1);
+            roundUp = remainder > half || (remainder == half && (result & 1) == 1);
+        } else if (shift < 128) {
+            final int highShift = shift - 64;
+            result = high >>> highShift;
+            if (result < 0) {
+                return -1;
+            }
+            // remainder = (high & mask(highShift)) : low, compared against half = 2^(shift-1)
+            final long remainderHigh = highShift == 0 ? 0 : high & ((1L << highShift) - 1);
+            final int compare;
+            if (highShift == 0) {
+                // half = 2^63: compare low (unsigned) against 2^63
+                compare = Long.compareUnsigned(low, 1L << 63);
+            } else {
+                final long halfHigh = 1L << (highShift - 1);
+                compare = remainderHigh != halfHigh
+                        ? Long.compareUnsigned(remainderHigh, halfHigh)
+                        : (low != 0 ? 1 : 0);
+            }
+            roundUp = compare > 0 || (compare == 0 && (result & 1) == 1);
+        } else {
+            return 0; // the value is far smaller than half of 1, it rounds to 0
+        }
+        return roundUp ? result + 1 : result;
+    }
+
+    /** Builds the "[sign]integer[.fraction]" bytes for scaled = round(|value| * 10^precision) */
+    private byte[] fixedDigits(int precision, boolean negative, long scaled) {
+        final long integerPart = scaled / POW10[precision];
+        final long fractionPart = scaled - integerPart * POW10[precision];
+
+        int integerLength = 1;
+        for (long remaining = integerPart; remaining >= 10; remaining /= 10) {
+            integerLength++;
+        }
+
+        final byte signChar;
+        if (negative) {
+            signChar = '-';
+        } else if (hasPlusFlag) {
+            signChar = '+';
+        } else if (hasSpaceFlag) {
+            signChar = ' ';
+        } else {
+            signChar = 0;
+        }
+
+        final boolean dot = precision > 0 || hasFSharpFlag;
+        final int length = (signChar != 0 ? 1 : 0) + integerLength + (dot ? 1 : 0) + precision;
+        final byte[] bytes = new byte[length];
+        int index = 0;
+        if (signChar != 0) {
+            bytes[index++] = signChar;
+        }
+        writeDigits(bytes, index, integerLength, integerPart);
+        index += integerLength;
+        if (dot) {
+            bytes[index++] = '.';
+            writeDigits(bytes, index, precision, fractionPart);
+        }
+        return bytes;
+    }
+
+    private static void writeDigits(byte[] bytes, int start, int length, long value) {
+        long remaining = value;
+        for (int i = start + length - 1; i >= start; i--) {
+            bytes[i] = (byte) ('0' + (remaining % 10));
+            remaining /= 10;
+        }
+        assert remaining == 0;
+    }
+
+    @TruffleBoundary
+    private byte[] slowFormat(int precision, Object value) {
         final byte[] digits;
         DecimalFormat format = getLanguage().getCurrentThread().formatFFloat;
         if (format == null) {


### PR DESCRIPTION
* Formatting a Float with %f went through java.text.DecimalFormat, reconfigured on every call, with FloatingDecimal digit generation dominating profiles of ERB template rendering (~20% of total CPU of a parallel rendering benchmark).
* The fast path computes round_half_even(|value| * 10^precision) exactly: value * 10^precision = mantissa * 5^precision * 2^(exponent + precision), computed in 128 bits and rounded once, then written out as bytes directly. It covers precision <= 17 when the scaled value fits in a long, otherwise the DecimalFormat path is used as before.
* This rounds like C printf on the exact decimal value of the double, which also matches CRuby on high precisions where the previous DecimalFormat code printed zeros beyond the shortest representation. ERB renders in that benchmark go from ~1300/s to ~2700/s.

- [ ] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
