### PR TITLE
 Preserve the handles of native array storage elements, not only the objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Bug fixes:
 * Fix `FFI::Pointer.new(FFI::Pointer)` to keep the original Pointer alive like CRuby (#4347, @eregon).
 * Check that `Symbol`s are always created from a non-broken `String` (@eregon).
 * Fix converting the same mutable `String` to native memory concurrently (@eregon).
+* Fix keeping `Float` and big `Integer` elements of an `Array` converted to native storage by `RARRAY_PTR()` alive (@eregon).
 
 Compatibility:
 

--- a/spec/ruby/optional/capi/array_spec.rb
+++ b/spec/ruby/optional/capi/array_spec.rb
@@ -273,6 +273,17 @@ describe "C-API Array function" do
       b.should == [1, 2, 3]
       a.should == [1, 2, 3] # check a was not modified
     end
+
+    it "keeps Float elements alive across GC and later accesses" do
+      a = [1.5, 2.5, 3.5]
+      @s.RARRAY_PTR_iterate(a) { |e| }
+      GC.start
+      b = []
+      @s.RARRAY_PTR_iterate(a) do |e|
+        b << e
+      end
+      b.should == [1.5, 2.5, 3.5]
+    end
   end
 
   describe "RARRAY_LEN" do

--- a/spec/tags/optional/capi/array_tags.txt
+++ b/spec/tags/optional/capi/array_tags.txt
@@ -1,1 +1,2 @@
 fails(deprecated):C-API Array function rb_iterate calls a function with the other function available as a block
+slow:C-API Array function RARRAY_PTR keeps Float elements alive across GC and later accesses

--- a/src/main/java/org/truffleruby/cext/ToWrapperNode.java
+++ b/src/main/java/org/truffleruby/cext/ToWrapperNode.java
@@ -31,6 +31,10 @@ import org.truffleruby.language.RubyBaseNode;
 @ImportStatic(ValueWrapperManager.class)
 public abstract class ToWrapperNode extends RubyBaseNode {
 
+    public static ValueWrapper executeUncached(long handle) {
+        return ToWrapperNodeGen.getUncached().execute(null, handle);
+    }
+
     /** Returns null for invalid handles */
     public abstract ValueWrapper execute(Node node, long handle);
 

--- a/src/main/java/org/truffleruby/core/array/library/NativeArrayStorage.java
+++ b/src/main/java/org/truffleruby/core/array/library/NativeArrayStorage.java
@@ -20,7 +20,9 @@ import com.oracle.truffle.api.dsl.Bind;
 import com.oracle.truffle.api.nodes.Node;
 import com.oracle.truffle.api.profiles.LoopConditionProfile;
 import org.truffleruby.RubyContext;
+import org.truffleruby.cext.ToWrapperNode;
 import org.truffleruby.cext.UnwrapNode;
+import org.truffleruby.cext.ValueWrapper;
 import org.truffleruby.cext.ValueWrapperManager.WrapperToHandleNode;
 import org.truffleruby.cext.WrapNode;
 import org.truffleruby.core.array.ArrayGuards;
@@ -291,8 +293,14 @@ public final class NativeArrayStorage implements ObjectGraphNode {
     @TruffleBoundary
     public void preserveMembers() {
         for (int i = 0; i < length; i++) {
-            final Object value = UnwrapNode.executeUncached(readElement(i));
-            markedObjects[i] = value;
+            final ValueWrapper wrapper = ToWrapperNode.executeUncached(readElement(i));
+            if (wrapper != null) {
+                /* Preserve the ValueWrapper and not just the unwrapped object: for a Float or Bignum-range integer, the
+                 * boxed value does not reference its ValueWrapper back, so preserving only the box would let the
+                 * wrapper and its HandleBlock be collected while the native storage still holds the handle. The wrapper
+                 * strongly references both the object and its block. */
+                markedObjects[i] = wrapper;
+            }
         }
     }
 }


### PR DESCRIPTION
- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
