### PR TITLE
Fix Marshal.load with extended objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Bug fixes:
 * Check that `Symbol`s are always created from a non-broken `String` (@eregon).
 * Fix converting the same mutable `String` to native memory concurrently (@eregon).
 * Fix keeping `Float` and big `Integer` elements of an `Array` converted to native storage by `RARRAY_PTR()` alive (@eregon).
+* Fix `Marshal.load` for an object extended with a module containing a nested user-marshaled object (#3943, @andrykonchin).
 
 Compatibility:
 

--- a/spec/ruby/core/marshal/fixtures/marshal_data.rb
+++ b/spec/ruby/core/marshal/fixtures/marshal_data.rb
@@ -159,6 +159,48 @@ class UserMarshalWithIvar
 end
 
 module MarshalSpec
+  class UserMarshalWithModuleCheck
+    def marshal_dump
+      :data
+    end
+
+    def marshal_load(data)
+      ScratchPad.record respond_to?(:meths_method)
+    end
+  end
+
+  class UserMarshalWithPayload
+    attr_accessor :payload
+
+    def initialize(payload)
+      @payload = payload
+    end
+
+    def marshal_dump
+      @payload
+    end
+
+    def marshal_load(payload)
+      @payload = payload
+    end
+  end
+
+  class UserDefinedWithPayload
+    attr_accessor :payload
+
+    def initialize(payload)
+      @payload = payload
+    end
+
+    def _dump(depth)
+      Marshal.dump(@payload)
+    end
+
+    def self._load(str)
+      new(Marshal.load(str))
+    end
+  end
+
   class UserMarshalDumpWithIvar
     attr_reader :data
 

--- a/spec/ruby/core/marshal/load_spec.rb
+++ b/spec/ruby/core/marshal/load_spec.rb
@@ -314,6 +314,47 @@ describe "Marshal.load" do
       object.string.should == "a".encode("utf-32le")
     end
 
+    it "loads an object extended with a module" do
+      obj = UserDefined.new
+      dump = "\x04\be:\nMethsu:\x10UserDefined\x12\x04\b[\a:\nstuff;\x00"
+      dump.should == "\x04\be:\nMeths" + Marshal.dump(obj)[2..-1]
+      loaded = Marshal.load(dump)
+      loaded.should.instance_of?(UserDefined)
+      loaded.singleton_class.ancestors[@num_self_class, 2].should == [Meths, UserDefined]
+    end
+
+    it "does not leak the extending module to nested objects when loading an extended user-defined _dump/_load object" do
+      obj = MarshalSpec::UserDefinedWithPayload.new(Object.new)
+      dump = "\x04\be:\nMethsu:(MarshalSpec::UserDefinedWithPayload\x11\x04\bo:\vObject\x00"
+      dump.should == "\x04\be:\nMeths" + Marshal.dump(obj)[2..-1]
+      loaded = Marshal.load(dump)
+      loaded.should.is_a?(Meths)
+      loaded.payload.should_not.is_a?(Meths)
+    end
+
+    it "isolates extending modules between an extended user-defined _dump/_load object and a nested object extended with another module" do
+      obj = MarshalSpec::UserDefinedWithPayload.new(Object.new.extend(MethsMore))
+      dump = "\x04\be:\nMethsu:(MarshalSpec::UserDefinedWithPayload\x1D\x04\be:\x0EMethsMoreo:\vObject\x00"
+      dump.should == "\x04\be:\nMeths" + Marshal.dump(obj)[2..-1]
+      loaded = Marshal.load(dump)
+      loaded.should.is_a?(Meths)
+      loaded.should_not.is_a?(MethsMore)
+      loaded.payload.should.is_a?(MethsMore)
+      loaded.payload.should_not.is_a?(Meths)
+    end
+
+    it "isolates extending modules between an extended user-defined _dump/_load object and a nested user-defined payload extended with another module" do
+      payload = UserDefined.new
+      nested_dump = "\x04\be:\x0EMethsMore" + Marshal.dump(payload)[2..-1]
+      dump = "\x04\be:\nMethsu:(MarshalSpec::UserDefinedWithPayload/\x04\be:\x0EMethsMoreu:\x10UserDefined\x12\x04\b[\a:\nstuff;\x00"
+      dump.should == "\x04\be:\nMethsu:(MarshalSpec::UserDefinedWithPayload" + [nested_dump.bytesize + 5].pack("C") + nested_dump
+      loaded = Marshal.load(dump)
+      loaded.should.is_a?(Meths)
+      loaded.should_not.is_a?(MethsMore)
+      loaded.payload.should.is_a?(MethsMore)
+      loaded.payload.should_not.is_a?(Meths)
+    end
+
     describe "that returns an immediate value" do
       it "loads an array containing an instance of the object, followed by multiple instances of another object" do
         str = "string"
@@ -476,6 +517,26 @@ describe "Marshal.load" do
       new_obj_ancestors = class << new_obj; ancestors[1..-1]; end
       obj_ancestors.should == new_obj_ancestors
     end
+
+    it "does not leak the extending module to nested elements when loading an extended Array" do
+      obj = [Object.new].extend(Meths)
+      dump = "\x04\be:\nMeths[\x06o:\vObject\x00"
+      dump.should == Marshal.dump(obj)
+      loaded = Marshal.load(dump)
+      loaded.should.is_a?(Meths)
+      loaded[0].should_not.is_a?(Meths)
+    end
+
+    it "isolates extending modules between an extended Array and a nested element extended with another module" do
+      obj = [Object.new.extend(MethsMore)].extend(Meths)
+      dump = "\x04\be:\nMeths[\x06e:\x0EMethsMoreo:\vObject\x00"
+      dump.should == Marshal.dump(obj)
+      loaded = Marshal.load(dump)
+      loaded.should.is_a?(Meths)
+      loaded.should_not.is_a?(MethsMore)
+      loaded[0].should.is_a?(MethsMore)
+      loaded[0].should_not.is_a?(Meths)
+    end
   end
 
   describe "for a Hash" do
@@ -499,6 +560,26 @@ describe "Marshal.load" do
       new_obj_metaclass_ancestors = class << new_obj; ancestors; end
       new_obj_metaclass_ancestors[@num_self_class].should == Meths
       new_obj_metaclass_ancestors[@num_self_class+1].should == Hash
+    end
+
+    it "does not leak the extending module to nested objects when loading an extended Hash" do
+      obj = { key: Object.new }.extend(Meths)
+      dump = "\x04\be:\nMeths{\x06:\bkeyo:\vObject\x00"
+      dump.should == Marshal.dump(obj)
+      loaded = Marshal.load(dump)
+      loaded.should.is_a?(Meths)
+      loaded[:key].should_not.is_a?(Meths)
+    end
+
+    it "isolates extending modules between an extended Hash and a nested object extended with another module" do
+      obj = { key: Object.new.extend(MethsMore) }.extend(Meths)
+      dump = "\x04\be:\nMeths{\x06:\bkeye:\x0EMethsMoreo:\vObject\x00"
+      dump.should == Marshal.dump(obj)
+      loaded = Marshal.load(dump)
+      loaded.should.is_a?(Meths)
+      loaded.should_not.is_a?(MethsMore)
+      loaded[:key].should.is_a?(MethsMore)
+      loaded[:key].should_not.is_a?(Meths)
     end
 
     it "preserves hash ivars when hash contains a string having ivar" do
@@ -678,6 +759,51 @@ describe "Marshal.load" do
       result.should == str
     end
 
+    it "loads an extended String" do
+      dump = "\x04\be:\nMeths\"\bfoo"
+      loaded = Marshal.load(dump)
+      loaded.should == "foo"
+      loaded.singleton_class.ancestors[@num_self_class, 2].should == [Meths, String]
+    end
+
+    it "loads an extended String with instance variables" do
+      dump = "\x04\bIe:\nMeths\"\bfoo\x06:\a@xT"
+      loaded = Marshal.load(dump)
+      loaded.should == "foo"
+      loaded.instance_variable_get(:@x).should == true
+      loaded.singleton_class.ancestors[@num_self_class, 2].should == [Meths, String]
+    end
+
+    it "loads an extended String subclass" do
+      dump = "\x04\be:\nMethsC:\x0FUserString\"\bfoo"
+      loaded = Marshal.load(dump)
+      loaded.should.instance_of?(UserString)
+      loaded.should == "foo"
+      loaded.singleton_class.ancestors[@num_self_class, 3].should == [Meths, UserString, String]
+    end
+
+    it "does not leak the extending module to instance variables when loading an extended String" do
+      obj = "hello".dup.force_encoding("BINARY").extend(Meths)
+      obj.instance_variable_set(:@ivar, Object.new)
+      dump = "\x04\bIe:\nMeths\"\nhello\x06:\n@ivaro:\vObject\x00"
+      dump.should == Marshal.dump(obj)
+      loaded = Marshal.load(dump)
+      loaded.should.is_a?(Meths)
+      loaded.instance_variable_get(:@ivar).should_not.is_a?(Meths)
+    end
+
+    it "isolates extending modules between an extended String and an instance variable extended with another module" do
+      obj = "hello".dup.force_encoding("BINARY").extend(Meths)
+      obj.instance_variable_set(:@ivar, Object.new.extend(MethsMore))
+      dump = "\x04\bIe:\nMeths\"\nhello\x06:\n@ivare:\x0EMethsMoreo:\vObject\x00"
+      dump.should == Marshal.dump(obj)
+      loaded = Marshal.load(dump)
+      loaded.should.is_a?(Meths)
+      loaded.should_not.is_a?(MethsMore)
+      loaded.instance_variable_get(:@ivar).should.is_a?(MethsMore)
+      loaded.instance_variable_get(:@ivar).should_not.is_a?(Meths)
+    end
+
     it "raises ArgumentError when end of byte sequence reached before string characters end" do
       Marshal.dump("hello").should == "\x04\b\"\nhello"
 
@@ -699,6 +825,26 @@ describe "Marshal.load" do
       dump = "\004\be:\nMethsS:\025Struct::Extended\a:\006a[\a;\a\"\ahi:\006b[\a;\000@\a"
       Marshal.load(dump).should == obj
       Struct.send(:remove_const, :Extended)
+    end
+
+    it "does not leak the extending module to member objects when loading an extended Struct" do
+      obj = Struct::Useful.new(Object.new, nil).extend(Meths)
+      dump = "\x04\be:\nMethsS:\x13Struct::Useful\a:\x06ao:\vObject\x00:\x06b0"
+      dump.should == Marshal.dump(obj)
+      loaded = Marshal.load(dump)
+      loaded.should.is_a?(Meths)
+      loaded.a.should_not.is_a?(Meths)
+    end
+
+    it "isolates extending modules between an extended Struct and a member object extended with another module" do
+      obj = Struct::Useful.new(Object.new.extend(MethsMore), nil).extend(Meths)
+      dump = "\x04\be:\nMethsS:\x13Struct::Useful\a:\x06ae:\x0EMethsMoreo:\vObject\x00:\x06b0"
+      dump.should == Marshal.dump(obj)
+      loaded = Marshal.load(dump)
+      loaded.should.is_a?(Meths)
+      loaded.should_not.is_a?(MethsMore)
+      loaded.a.should.is_a?(MethsMore)
+      loaded.a.should_not.is_a?(Meths)
     end
 
     it "loads a struct having ivar" do
@@ -820,6 +966,28 @@ describe "Marshal.load" do
       new_obj_metaclass_ancestors[@num_self_class, 2].should == [Meths, Object]
     end
 
+    it "does not leak the extending module to instance variables when loading an extended Object" do
+      obj = Object.new.extend(Meths)
+      obj.instance_variable_set(:@ivar, Object.new)
+      dump = "\x04\be:\nMethso:\vObject\x06:\n@ivaro;\x06\x00"
+      dump.should == Marshal.dump(obj)
+      loaded = Marshal.load(dump)
+      loaded.should.is_a?(Meths)
+      loaded.instance_variable_get(:@ivar).should_not.is_a?(Meths)
+    end
+
+    it "isolates extending modules between an extended Object and an instance variable extended with another module" do
+      obj = Object.new.extend(Meths)
+      obj.instance_variable_set(:@ivar, Object.new.extend(MethsMore))
+      dump = "\x04\be:\nMethso:\vObject\x06:\n@ivare:\x0EMethsMoreo;\x06\x00"
+      dump.should == Marshal.dump(obj)
+      loaded = Marshal.load(dump)
+      loaded.should.is_a?(Meths)
+      loaded.should_not.is_a?(MethsMore)
+      loaded.instance_variable_get(:@ivar).should.is_a?(MethsMore)
+      loaded.instance_variable_get(:@ivar).should_not.is_a?(Meths)
+    end
+
     it "loads an object having ivar" do
       s = 'hi'
       arr = [:so, :so, s, s]
@@ -864,6 +1032,60 @@ describe "Marshal.load" do
       dump.should == "\x04\b[\aU:\x10UserMarshal:\tdata;\x06"
       reloaded = Marshal.load(dump)
       reloaded.should == value
+    end
+
+    it "loads a user-marshaled object extended with a module" do
+      obj = UserMarshal.new
+      obj.data = :data
+      dump = "\x04\be:\nMethsU:\x10UserMarshal:\tdata"
+      dump.should == "\x04\be:\nMeths" + Marshal.dump(obj)[2..-1]
+      loaded = Marshal.load(dump)
+      loaded.should.instance_of?(UserMarshal)
+      loaded.data.should == :data
+      loaded.singleton_class.ancestors[@num_self_class, 2].should == [Meths, UserMarshal]
+    end
+
+    it "extends the module before calling #marshal_load on a user-marshaled object" do
+      obj = MarshalSpec::UserMarshalWithModuleCheck.new
+      dump = "\x04\be:\nMethsU:,MarshalSpec::UserMarshalWithModuleCheck:\tdata"
+      dump.should == "\x04\be:\nMeths" + Marshal.dump(obj)[2..-1]
+      ScratchPad.record nil
+      loaded = Marshal.load(dump)
+      ScratchPad.recorded.should == true
+      loaded.should.is_a?(Meths)
+    end
+
+    it "does not leak the extending module to nested payload objects when loading an extended user-marshaled object" do
+      obj = MarshalSpec::UserMarshalWithPayload.new(Object.new)
+      dump = "\x04\be:\nMethsU:(MarshalSpec::UserMarshalWithPayloado:\vObject\x00"
+      dump.should == "\x04\be:\nMeths" + Marshal.dump(obj)[2..-1]
+      loaded = Marshal.load(dump)
+      loaded.should.is_a?(Meths)
+      loaded.payload.should_not.is_a?(Meths)
+    end
+
+    it "isolates extending modules between an extended user-marshaled object and a nested payload object extended with another module" do
+      obj = MarshalSpec::UserMarshalWithPayload.new(Object.new.extend(MethsMore))
+      dump = "\x04\be:\nMethsU:(MarshalSpec::UserMarshalWithPayloade:\x0EMethsMoreo:\vObject\x00"
+      dump.should == "\x04\be:\nMeths" + Marshal.dump(obj)[2..-1]
+      loaded = Marshal.load(dump)
+      loaded.should.is_a?(Meths)
+      loaded.should_not.is_a?(MethsMore)
+      loaded.payload.should.is_a?(MethsMore)
+      loaded.payload.should_not.is_a?(Meths)
+    end
+
+    it "isolates extending modules between an extended user-marshaled object and a nested user-marshaled payload extended with another module" do
+      payload = UserMarshal.new
+      payload.data = :data
+      nested_dump = "\x04\be:\x0EMethsMore" + Marshal.dump(payload)[2..-1]
+      dump = "\x04\be:\nMethsU:(MarshalSpec::UserMarshalWithPayloade:\x0EMethsMoreU:\x10UserMarshal:\tdata"
+      dump.should == "\x04\be:\nMethsU:(MarshalSpec::UserMarshalWithPayload" + nested_dump[2..-1]
+      loaded = Marshal.load(dump)
+      loaded.should.is_a?(Meths)
+      loaded.should_not.is_a?(MethsMore)
+      loaded.payload.should.is_a?(MethsMore)
+      loaded.payload.should_not.is_a?(Meths)
     end
   end
 
@@ -1265,6 +1487,26 @@ describe "Marshal.load" do
       data = "\004\bd:\020UserDefined\0"
 
       -> { Marshal.load(data) }.should.raise(ArgumentError)
+    end
+  end
+
+  describe "for an object extended with a module" do
+    it "loads an object extended with multiple modules preserving the module ancestor order" do
+      dump = "\x04\be:\nMethse:\x0EMethsMoreo:\vObject\x00"
+      loaded = Marshal.load(dump)
+      loaded.singleton_class.ancestors[@num_self_class, 3].should == [Meths, MethsMore, Object]
+    end
+
+    it "raises ArgumentError when the extending module does not exist" do
+      -> {
+        Marshal.load("\x04\be:\x16NonExistentModuleo:\vObject\x00")
+      }.should.raise(ArgumentError, /undefined class\/module/)
+    end
+
+    it "raises ArgumentError when the extending constant is a Class instead of a Module" do
+      -> {
+        Marshal.load("\x04\be:\vStringo:\vObject\x00")
+      }.should.raise(ArgumentError)
     end
   end
 

--- a/spec/ruby/core/marshal/load_spec.rb
+++ b/spec/ruby/core/marshal/load_spec.rb
@@ -976,6 +976,16 @@ describe "Marshal.load" do
       loaded.instance_variable_get(:@ivar).should_not.is_a?(Meths)
     end
 
+    it "does not leak the extending module to a user-marshaled instance variable when loading an extended Object" do
+      obj = Object.new.extend(Meths)
+      obj.instance_variable_set(:@ivar, UserMarshal.new)
+      dump = "\x04\be:\nMethso:\vObject\x06:\n@ivarU:\x10UserMarshal:\tdata"
+      dump.should == Marshal.dump(obj)
+      loaded = Marshal.load(dump)
+      loaded.should.is_a?(Meths)
+      loaded.instance_variable_get(:@ivar).should_not.is_a?(Meths)
+    end
+
     it "isolates extending modules between an extended Object and an instance variable extended with another module" do
       obj = Object.new.extend(Meths)
       obj.instance_variable_set(:@ivar, Object.new.extend(MethsMore))

--- a/spec/tags/core/marshal/load_tags.txt
+++ b/spec/tags/core/marshal/load_tags.txt
@@ -10,6 +10,3 @@ fails:Marshal.load for a Regexp restore the regexp instance variables
 fails:Marshal.load for a Regexp loads a Regexp subclass instance variables when it is extended with a module
 fails:Marshal.load for a String sets binmode if it is loading through StringIO stream
 fails:Marshal.load for a Regexp loads a Regexp subclass instance variables
-fails:Marshal.load for an Array isolates extending modules between an extended Array and a nested element extended with another module
-fails:Marshal.load for a Struct isolates extending modules between an extended Struct and a member object extended with another module
-fails:Marshal.load for an Object isolates extending modules between an extended Object and an instance variable extended with another module

--- a/spec/tags/core/marshal/load_tags.txt
+++ b/spec/tags/core/marshal/load_tags.txt
@@ -10,3 +10,6 @@ fails:Marshal.load for a Regexp restore the regexp instance variables
 fails:Marshal.load for a Regexp loads a Regexp subclass instance variables when it is extended with a module
 fails:Marshal.load for a String sets binmode if it is loading through StringIO stream
 fails:Marshal.load for a Regexp loads a Regexp subclass instance variables
+fails:Marshal.load for an Array isolates extending modules between an extended Array and a nested element extended with another module
+fails:Marshal.load for a Struct isolates extending modules between an extended Struct and a member object extended with another module
+fails:Marshal.load for an Object isolates extending modules between an extended Object and an instance variable extended with another module

--- a/src/main/ruby/truffleruby/core/marshal.rb
+++ b/src/main/ruby/truffleruby/core/marshal.rb
@@ -610,7 +610,6 @@ module Marshal
       end
 
       @consumed = 0
-      @modules = nil
       @has_ivar = []
       @proc = proc
       @freeze = freeze
@@ -683,7 +682,9 @@ module Marshal
       @symlinks[obj.__id__] = sz
     end
 
-    def construct(ivar_index = nil, call_proc = true, postpone_freezing = false)
+    # Pass `modules` to avoid leaking extending modules (?e) to nested objects
+    # and extend user-marshaled (?U) objects before #marshal_load is called.
+    def construct(ivar_index = nil, call_proc = true, postpone_freezing = false, modules = nil)
       type = consume_byte()
       obj = case type
             when 48   # ?0
@@ -723,7 +724,7 @@ module Marshal
             when 117  # ?u
               construct_user_defined(ivar_index)
             when 85   # ?U
-              construct_user_marshal
+              construct_user_marshal(modules)
             when 100  # ?d
               construct_data
             when 64   # ?@
@@ -744,14 +745,17 @@ module Marshal
 
               return sym
             when 101  # ?e
-              @modules ||= []
-
               name = get_symbol
-              @modules << const_lookup(name, Module)
+              mod = const_lookup(name, Module)
+              modules ||= []
+              modules << mod
 
-              obj = construct nil, false, true
+              obj = construct nil, false, true, modules
 
-              extend_object obj
+              until modules.empty?
+                m = modules.pop
+                extend_object obj, m
+              end
 
               obj
             when 67   # ?C
@@ -761,13 +765,13 @@ module Marshal
               @user_classes ||= []
               @user_classes << name
 
-              construct nil, false, postpone_freezing
+              construct nil, false, postpone_freezing, modules
 
             when 73   # ?I
               ivar_index = @has_ivar.length
               @has_ivar.push true
 
-              obj = construct ivar_index, false, true
+              obj = construct ivar_index, false, true, modules
 
               set_instance_variables obj if @has_ivar.pop
 
@@ -896,11 +900,8 @@ module Marshal
       store_unique_object obj
 
       construct_integer.times do
-        original_modules = @modules
-        @modules = nil
         key = construct
         val = construct
-        @modules = original_modules
 
         # Use Primitive.hash_store (an alias for []=) to get around subclass overrides
         Primitive.hash_store(obj, key, val)
@@ -1067,13 +1068,18 @@ module Marshal
       obj
     end
 
-    def construct_user_marshal
+    def construct_user_marshal(modules)
       name = get_symbol
 
       klass = const_lookup name, Class
       obj = klass.allocate
 
-      extend_object obj if @modules
+      if modules
+        until modules.empty?
+          mod = modules.pop
+          extend_object obj, mod
+        end
+      end
 
       unless Primitive.respond_to? obj, :marshal_load, true
         raise TypeError, "instance of #{klass} needs to have method 'marshal_load'"
@@ -1084,12 +1090,9 @@ module Marshal
       obj
     end
 
-    def extend_object(obj)
-      until @modules.empty?
-        mod = @modules.pop
-        mod.__send__ :extend_object, obj
-        mod.__send__ :extended, obj
-      end
+    def extend_object(obj, mod)
+      mod.__send__ :extend_object, obj
+      mod.__send__ :extended, obj
     end
 
     def find_link(obj)


### PR DESCRIPTION
Fixed `Marshal.load` when there are objects extended with a module.

When `Marshal.load` is deserializing an object extended with a module, nested objects (instance variables or a container (Hash/Array/Struct) elements) with custom marshalling (that's implementing `#marshal_dump` and `#marshal_load` methods) were incorrectly extended with that module instead of the parent object.

Closes #3943.

## `mime-types` notes

The issue cased failures of `mime-types` tests (it's also tracked on the gems-tracker).

In `mime-types`, `MIME::Types` instances are extended with `MIME::Types::Columnar` module (which defines `#load_preferred_extension` method) and holds instance variables that implement `#marshal_dump`/`#marshal_load`. When `test_mime_types_cache.rb` loaded the cached `MIME::Types` object with `Marshal.load`, this bug extended its instance variable with `MIME::Types::Columnar` instead of `MIME::Types` itself. As a result, `MIME::Types` was left missing `load_preferred_extension`, causing sporadic `NoMethodError` failures in subsequent tests depending on randomized test order.

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
