### PR TITLE
Update docker tests to use non-EOL versions and test the latest releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,7 +95,7 @@ jobs:
       matrix:
         arch: [amd64, aarch64]
         # Keep this list in sync with tool/docker-configs.yaml
-        image: [ol8, ol9, ol10, fedora37, fedora38, ubuntu2004, ubuntu2204, debian11, debian12, debian13]
+        image: [ol8, ol9, ol10, fedora43, fedora44, ubuntu2004, ubuntu2204, ubuntu2404, ubuntu2604, debian12, debian13]
     runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-22.04' || 'ubuntu-22.04-arm' }}
     steps:
     - name: Clone TruffleRuby

--- a/tool/docker-configs.yaml
+++ b/tool/docker-configs.yaml
@@ -65,11 +65,6 @@ ubuntu2204:
   install: RUN apt-get update && apt-get install -y
   <<: *deb
 
-debian11:
-  base: debian:11 # bullseye
-  install: RUN apt-get update && apt-get install -y
-  <<: *deb
-
 debian12:
   base: debian:12 # bookworm
   install: RUN apt-get update && apt-get install -y

--- a/tool/docker-configs.yaml
+++ b/tool/docker-configs.yaml
@@ -43,14 +43,14 @@ ol10:
   locale: glibc-langpack-en
   <<: *rpm
 
-fedora37:
-  base: fedora:37
+fedora43:
+  base: fedora:43
   install: RUN dnf install -y
   locale: glibc-langpack-en
   <<: *rpm
 
-fedora38:
-  base: fedora:38
+fedora44:
+  base: fedora:44
   install: RUN dnf install -y
   locale: glibc-langpack-en
   <<: *rpm

--- a/tool/docker-configs.yaml
+++ b/tool/docker-configs.yaml
@@ -23,7 +23,7 @@ deb: &deb
     - RUN locale-gen
     - ENV LANG=en_US.UTF-8
 
-# Keep this list in sync with the docker-test.yml workflow
+# Keep this list in sync with the release.yml workflow
 
 ol8:
   base: oraclelinux:8-slim

--- a/tool/docker-configs.yaml
+++ b/tool/docker-configs.yaml
@@ -65,6 +65,16 @@ ubuntu2204:
   install: RUN apt-get update && apt-get install -y
   <<: *deb
 
+ubuntu2404:
+  base: ubuntu:24.04
+  install: RUN apt-get update && apt-get install -y
+  <<: *deb
+
+ubuntu2604:
+  base: ubuntu:26.04
+  install: RUN apt-get update && apt-get install -y
+  <<: *deb
+
 debian12:
   base: debian:12 # bookworm
   install: RUN apt-get update && apt-get install -y


### PR DESCRIPTION
Using https://endoflife.date/debian to find out non-EOL versions.
To fix Debian 11 (EOL now) failing: https://github.com/truffleruby/truffleruby/actions/runs/33946074742/job/101357202059#step:6:177

Run: https://github.com/truffleruby/truffleruby/actions/runs/33988207588