### PR TITLE
Pass the block given to Data subclass new down to #initialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ Compatibility:
 * Run a signal handler immediately when `Process.kill(signal, Process.pid)` is called on the main Thread (#4383, @eregon).
 * Fix `Module#module_function` and keep new Module methods public created from implicitly private callbacks (#4388, @andrykonchin).
 * Add `flags` keyword argument to `Dir.glob` as an alternative to the positional argument (#4394, @earlopain).
+* Fix `new` on `Data` subclasses to pass the given block to `#initialize` (@eregon).
 
 Performance:
 

--- a/spec/ruby/core/data/initialize_spec.rb
+++ b/spec/ruby/core/data/initialize_spec.rb
@@ -180,6 +180,19 @@ describe "Data#initialize" do
       ScratchPad.recorded.should == [:initialize, [], {amount: 42, unit: "m"}]
     end
 
+    it "receives the block passed to .new" do
+      klass = Data.define(:amount) do
+        def initialize(amount:, &block)
+          super(amount: block.call(amount))
+        end
+      end
+
+      klass.new(1) { |amount| amount * 2 }.amount.should == 2
+      klass.new(amount: 1) { |amount| amount * 2 }.amount.should == 2
+      klass[1] { |amount| amount * 2 }.amount.should == 2
+      klass[amount: 1] { |amount| amount * 2 }.amount.should == 2
+    end
+
     it "accepts positional arguments with empty keyword arguments" do
       data = DataSpecs::SingleWithOverriddenName.new(42, **{})
 

--- a/src/main/ruby/truffleruby/core/data.rb
+++ b/src/main/ruby/truffleruby/core/data.rb
@@ -96,7 +96,7 @@ class Data
         undef_method :define
       end
 
-      def self.new(*args, **kwargs)
+      def self.new(*args, **kwargs, &block)
         if !args.empty? and !kwargs.empty?
           raise ArgumentError, "wrong number of arguments (given #{args.size + 1}, expected 0)"
         end
@@ -104,7 +104,7 @@ class Data
         instance = allocate
 
         if !kwargs.empty?
-          instance.send(:initialize, **kwargs)
+          instance.send(:initialize, **kwargs, &block)
         else
           if args.size > self::CLASS_MEMBERS.size
             raise ArgumentError, "wrong number of arguments (given #{args.size}, expected 0..#{self::CLASS_MEMBERS.size})"
@@ -115,7 +115,7 @@ class Data
             kwargs_for_initialize[self::CLASS_MEMBERS[i]] = arg
           end
 
-          instance.send(:initialize, **kwargs_for_initialize)
+          instance.send(:initialize, **kwargs_for_initialize, &block)
         end
 
         instance


### PR DESCRIPTION
Like CRuby, so an overridden #initialize can receive the block.

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
