### PR TITLE
Fix Regexp extended-mode comments to always end at a newline (#4435)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Bug fixes:
 * Fix converting the same mutable `String` to native memory concurrently (@eregon).
 * Fix keeping `Float` and big `Integer` elements of an `Array` converted to native storage by `RARRAY_PTR()` alive (@eregon).
 * Fix `Marshal.load` for an object extended with a module containing a nested user-marshaled object (#3943, @andrykonchin).
+* Fix `Regexp` comments in extended mode to always end at a newline, even when the newline is preceded by a backslash (#4435, @eregon).
 
 Compatibility:
 

--- a/mx.truffleruby/suite.py
+++ b/mx.truffleruby/suite.py
@@ -21,7 +21,7 @@ suite = {
             {
                 "name": "regex",
                 "subdir": True,
-                "version": "521a3ee1817c7495de25f2f57506029c90068692",
+                "version": "6338ada5df2b1683f4edc9b08e289f41a9d45fd3",
                 "urls": [
                     {"url": "https://github.com/truffleruby/graal.git", "kind": "git"},
                     {"url": "https://curio.ssw.jku.at/nexus/content/repositories/snapshots", "kind": "binary"},

--- a/spec/ruby/language/regexp/modifiers_spec.rb
+++ b/spec/ruby/language/regexp/modifiers_spec.rb
@@ -15,6 +15,11 @@ describe "Regexps with modifiers" do
     /\d +/x.match("abc123").to_a.should == ["123"] # Quantifiers can be separated from the expression they apply to
   end
 
+  it "ends a comment in extended syntax at a newline, even when the newline is preceded by a backslash" do
+    Regexp.new("(a) # comment \\\n(b)", Regexp::EXTENDED).match("ab").to_a.should == ["ab", "a", "b"]
+    Regexp.new("(x # comment \\\n)", Regexp::EXTENDED).match("x").to_a.should == ["x", "x"]
+  end
+
   it "supports /o (once)" do
     2.times do |i|
       /#{i}/o.should == /0/


### PR DESCRIPTION
Fixes https://github.com/truffleruby/truffleruby/issues/4435

A backslash at the end of a comment line must not escape the newline. The fix is in TRegex's Ruby flavor parser; update the graal import to include it and add a spec covering the MRI behavior.

TRegex PR: https://github.com/oracle/graal/pull/14398

- [x] Consider adding a ChangeLog entry if the change is visible or meaningful to users, see [CONTRIBUTING.md](https://github.com/truffleruby/truffleruby/blob/master/CONTRIBUTING.md#changelog) for details.
