### PR TITLE
Cache Regexp#to_s in RubyRegexp

### DIFF
--- a/src/main/java/org/truffleruby/core/regexp/RegexpNodes.java
+++ b/src/main/java/org/truffleruby/core/regexp/RegexpNodes.java
@@ -120,13 +120,7 @@ public abstract class RegexpNodes {
 
         @Specialization
         RubyString toS(RubyRegexp regexp) {
-            return createString(createTString(regexp));
-        }
-
-        @TruffleBoundary
-        protected TStringWithEncoding createTString(RubyRegexp regexp) {
-            var sourceEnc = new TStringWithEncoding(regexp.source, regexp.encoding);
-            return ClassicRegexp.toS(sourceEnc, regexp.options);
+            return createString(regexp.getCachedToS());
         }
     }
 

--- a/src/main/java/org/truffleruby/core/regexp/RubyRegexp.java
+++ b/src/main/java/org/truffleruby/core/regexp/RubyRegexp.java
@@ -76,6 +76,18 @@ public final class RubyRegexp extends ImmutableRubyObjectNotCopyable
     public final RegexpOptions options;
     public final EncodingCache cachedEncodings;
     public final TRegexCache tregexCache;
+    /** Lazily computed #to_s result. Immutable value, so racy initialization is fine. */
+    private volatile TStringWithEncoding toSResult;
+
+    @TruffleBoundary
+    public TStringWithEncoding getCachedToS() {
+        var toS = toSResult;
+        if (toS == null) {
+            toS = ClassicRegexp.toS(new TStringWithEncoding(source, encoding), options);
+            toSResult = toS;
+        }
+        return toS;
+    }
 
     private RubyRegexp(Regex regex, RegexpOptions options) {
         this.regex = regex;


### PR DESCRIPTION
Rails' ActiveSupport::ParameterFilter calls Regexp#to_s on the same
interned Regexps for every request. ClassicRegexp.toS re-parsed the
regexp source each call, and for sources like /(?i:a)|(?i:b)/ the
embeddability check compiles an unbalanced inner pattern with Joni,
throwing and swallowing a stack-trace-filling SyntaxException every
time: ~8% of railsbench CPU samples.

RubyRegexp is immutable and interned, so compute the #to_s TString
lazily once and reuse it.

Related: https://github.com/truffleruby/truffleruby/pull/4464
