### PR TITLE
Log Hash conversions to ConcurrentHashStore with --shared-objects-debug

### DIFF
--- a/src/main/java/org/truffleruby/core/hash/library/ConcurrentHashStore.java
+++ b/src/main/java/org/truffleruby/core/hash/library/ConcurrentHashStore.java
@@ -407,6 +407,11 @@ public final class ConcurrentHashStore {
 
     @TruffleBoundary
     public static void convertFromOtherStrategy(RubyHash hash) {
+        if (RubyLanguage.get(null).options.SHARED_OBJECTS_DEBUG) {
+            RubyLanguage.LOGGER.info("converting Hash of size " + hash.size + " to ConcurrentHashStore at:");
+            RubyContext.get(null).getDefaultBacktraceFormatter()
+                    .printBacktraceOnEnvStderr("hash-to-concurrent: ", null);
+        }
         int capacity = Math.max(BucketsHashStore.growthCapacityGreaterThan(hash.size), INITIAL_CAPACITY);
         ConcurrentHashStore concurrentHash = new ConcurrentHashStore(capacity);
 


### PR DESCRIPTION
Prints the Ruby backtrace of each conversion, which makes it easy to find which code writes Hashes into shared objects, e.g. on railsbench every request converts ~300 Hashes when ActiveRecord row attributes become reachable from a controller stored in the shared execution context.